### PR TITLE
Changed support label for Windows Phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   * **Apple Push Notification Service**
   * **Google Cloud Messaging**
   * **Amazon Devide Messaging**
-  * **Windows Push Notification Service**.
+  * **Windows Phone Push Notification Service**.
 * Seamless Rails (3, 4) integration.
 * Scalable - choose the number of persistent connections for each app.
 * Designed for uptime - signal -HUP to add, update apps.


### PR DESCRIPTION
The push notifications between Windows phone and Windows 8 are different. We'll need to add support for w8 in the future.
