### PR TITLE
Redis backend registers notifications for retrying

### DIFF
--- a/lib/rpush/client/redis/notification.rb
+++ b/lib/rpush/client/redis/notification.rb
@@ -50,6 +50,11 @@ module Rpush
           end
         end
 
+        def enqueue
+          save!(validate: false)
+          register_notification
+        end
+
         private
 
         def register_notification


### PR DESCRIPTION
mark_retryable for the Redis backend was setting the deliver_after field, but the query to retrieve deliverable notifications uses the "rpush:notifications:pending" sorted set, and those notifications were not being re-registered on that set. Please check if it's everything ok with this.
thanks!
