### PR TITLE
Improves notif validation to work better with ActiveRecord.

### DIFF
--- a/lib/rpush/client/active_model/notification.rb
+++ b/lib/rpush/client/active_model/notification.rb
@@ -5,7 +5,7 @@ module Rpush
         def self.included(base)
           base.instance_eval do
             validates :expiry, numericality: true, allow_nil: true
-            validates :app_id, presence: true
+            validates :app, presence: true
           end
         end
 

--- a/spec/unit/client/active_record/notification_spec.rb
+++ b/spec/unit/client/active_record/notification_spec.rb
@@ -12,4 +12,10 @@ describe Rpush::Client::ActiveRecord::Notification do
     notification.registration_ids = 'a'
     notification.registration_ids.should eq ['a']
   end
+
+  it 'saves its parent App if required' do
+    notification.app = Rpush::Client::ActiveRecord::App.new(name: "aname")
+    expect(notification.app).to be_valid
+    expect(notification).to be_valid
+  end
 end


### PR DESCRIPTION
Validating Notifications against app_id prevents the App (if it exists) to be saved before the validation occurs. An example:

```
pry(main)> notif = Rpush::Client::ActiveRecord::Notification.new
pry(main)> notif.app = Rpush::Client::ActiveRecord::App.new(name: "wut")
pry(main)> notif.app.tap(&:valid?).errors
=> @messages={} # valid
pry(main)> notif.valid?
=> false
pry(main)> notif.errors
=> @messages={:app_id=>["can't be blank"]}
```

This forces us to save the App before the Notification. So, **why is this important?** Mostly for testing. When we're testing notifications we just do a FactoryGirl.create(:rpush_apns_notif) and expect the associations to do the rest. The way it is, we are required to include extra code for saving the App as well.
