### PR TITLE
Add check for ::ActiveRecord::MassAssignmentSecurity

### DIFF
--- a/lib/rpush.rb
+++ b/lib/rpush.rb
@@ -4,7 +4,7 @@ require 'active_support/all'
 module Rpush
   def self.attr_accessible_available?
     require 'rails'
-    ::Rails::VERSION::STRING < '4'
+    ::Rails::VERSION::STRING < '4' || defined?(::ActiveRecord::MassAssignmentSecurity)
   end
 end
 


### PR DESCRIPTION
While using the gem `protected_attributes` we got the error `WARNING: Can't mass-assign protected attributes for Rpush::Apns::Feedback: failed_at, device_token, app`.

This happens because `self.attr_accessible_available?` returns `false` even we use that gem that enables the protected_attributes functionality back in Rails 4.
