### PR TITLE
Handle revoked certificates in the reflection api

### DIFF
--- a/lib/generators/templates/rpush.rb
+++ b/lib/generators/templates/rpush.rb
@@ -106,6 +106,10 @@ Rpush.reflect do |on|
   # on.ssl_certificate_will_expire do |app, expiration_time|
   # end
 
+  # Called when an SSL certificate has been revoked.
+  # on.ssl_certificate_revoked do |app, error|
+  # end
+
   # Called when the ADM returns a canonical registration ID.
   # You will need to replace old_id with canonical_id in your records.
   # on.adm_canonical_id do |old_id, canonical_id|

--- a/lib/rpush/daemon/tcp_connection.rb
+++ b/lib/rpush/daemon/tcp_connection.rb
@@ -108,6 +108,12 @@ module Rpush
         ssl_socket.sync = true
         ssl_socket.connect
         [tcp_socket, ssl_socket]
+      rescue => error
+        if error.message =~ /certificate revoked/
+          log_warn('Certificate has been revoked.')
+          reflect(:ssl_certificate_revoked, @app, error)
+        end
+        raise
       end
 
       def check_certificate_expiration

--- a/lib/rpush/reflection.rb
+++ b/lib/rpush/reflection.rb
@@ -15,7 +15,7 @@ module Rpush
       :notification_failed, :notification_will_retry, :gcm_delivered_to_recipient,
       :gcm_failed_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
       :error, :adm_canonical_id, :adm_failed_to_recipient,
-      :tcp_connection_lost, :ssl_certificate_will_expire,
+      :tcp_connection_lost, :ssl_certificate_will_expire, :ssl_certificate_revoked,
       :notification_id_will_retry, :notification_id_failed
     ]
 


### PR DESCRIPTION
APNS apps that have had their certificates revoked are hard to identify. The error message doesn't include the name of the app. This adds a `:ssl_certificate_revoked` method to the reflection api. From here you can identify, log, or delete the offending app.
