### PR TITLE
Add Safari Push Notification support

### DIFF
--- a/lib/rpush/client/active_model/apns/notification.rb
+++ b/lib/rpush/client/active_model/apns/notification.rb
@@ -39,9 +39,11 @@ module Rpush
           end
 
           URL_ARGS_KEY = '__rpush_url_args__'
-          def url_args=(array)
-            return unless array
-            self.data = (data || {}).merge(URL_ARGS_KEY => array)
+          def url_args=(url_args)
+            return unless url_args
+
+            url_args = url_args.is_a?(Array) ? url_args : [url_args.to_s]
+            self.data = (data || {}).merge(URL_ARGS_KEY => url_args)
           end
 
           def as_json # rubocop:disable Metrics/PerceivedComplexity

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -160,6 +160,11 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'url-args' do
     notification.as_json.key?('url-args').should be_false
   end
 
+  it 'also allows to pass strings as url-args' do
+    notification.url_args = 'url-arg-1'
+    notification.as_json['aps']['url-args'].should eq ['url-arg-1']
+  end
+
   it 'does not overwrite existing attributes for the device' do
     notification.data = { hi: :mom }
     notification.url_args = ['url-arg-1']


### PR DESCRIPTION
I added "Notification#url_args" to define the url_args that are send to the APNS Service.
The url_args are required for [Safari Push Notifications](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html).

Issue: https://github.com/rpush/rpush/issues/76
