### PR TITLE
Clarified format of iOS device token

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ app.save!
 ```ruby
 n = Rpush::Apns::Notification.new
 n.app = Rpush::Apns::App.find_by_name("ios_app")
-n.device_token = "..."
+n.device_token = "..." # 64-character hex string
 n.alert = "hi mom!"
 n.data = { foo: :bar }
 n.save!


### PR DESCRIPTION
Hi,

It wasn't immediately clear to me what format the iOS device token should be in - binary, base64 or hexadecimal. I added a comment to the sample code in the README to clarify. Do you think it's worth including?
