### PR TITLE
Update WPNS example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ app.save!
 n = Rpush::Wpns::Notification.new
 n.app = Rpush::Wpns::App.find_by_name("windows_phone_app")
 n.uri = "http://..."
-n.data = {title:"MyApp", body:"Hello world", param:"user_param1"}
+n.alert = "Hi there!"
 n.save!
 ```
 


### PR DESCRIPTION
Looks like instead of setting `data` on the notification we have to set `alert` to send a WPNS notification
