### PR TITLE
Notification Model String Hash

### DIFF
--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -21,7 +21,7 @@ module Rpush
 
         def data=(attrs)
           return unless attrs
-		  attrs = JSON.parse(attrs) if attrs.is_a?(String)
+          attrs = JSON.parse(attrs) if attrs.is_a?(String)
           fail ArgumentError, "must be a Hash" unless attrs.is_a?(Hash)
           write_attribute(:data, multi_json_dump(attrs.merge(data || {})))
         end

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -21,6 +21,7 @@ module Rpush
 
         def data=(attrs)
           return unless attrs
+		  attrs = JSON.parse(attrs) if attrs.is_a?(String)
           fail ArgumentError, "must be a Hash" unless attrs.is_a?(Hash)
           write_attribute(:data, multi_json_dump(attrs.merge(data || {})))
         end


### PR DESCRIPTION
I added a compatibility for ActiveAdmin which works with JSON as strings

Problem was I had always the Must be a Hash message because I was sending a string from a textfield.