### PR TITLE
Include Mongoid::Timestamp to record created_at and updated_at.

### DIFF
--- a/lib/rpush/client/mongoid/notification.rb
+++ b/lib/rpush/client/mongoid/notification.rb
@@ -3,6 +3,7 @@ module Rpush
     module Mongoid
       class Notification
         include ::Mongoid::Document
+        include ::Mongoid::Timestamps
         include ::Mongoid::Autoinc
         include Rpush::MultiJsonHelper
         include Rpush::Client::ActiveModel::Notification


### PR DESCRIPTION
`created_at` and `updated_at` timestamps is still useful for some purposes and they are also included in the ActiveRecord model.