### PR TITLE
ActiveAdmin support

### DIFF
--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -21,17 +21,26 @@ module Rpush
 
         def data=(attrs)
           return unless attrs
+          attrs = JSON.parse(attrs) if attrs.is_a?(String)
           fail ArgumentError, "must be a Hash" unless attrs.is_a?(Hash)
           write_attribute(:data, multi_json_dump(attrs.merge(data || {})))
         end
 
-        def registration_ids=(ids)
-          ids = [ids] if ids && !ids.is_a?(Array)
-          super
-        end
-
         def data
           multi_json_load(read_attribute(:data)) if read_attribute(:data)
+        end
+
+        def registration_ids=(ids)
+          if ids && ids.is_a?(String)
+            begin
+              data = JSON.parse(ids)
+              ids = data if data && data.is_a?(Array)
+            rescue JSON::ParserError => e
+              ids = ids.split(' ')
+            end
+          end
+          ids = [ids] if ids && !ids.is_a?(Array)
+          super
         end
       end
     end

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -23,7 +23,8 @@ module Rpush
           return unless attrs
           attrs = JSON.parse(attrs) if attrs.is_a?(String)
           fail ArgumentError, "must be a Hash" unless attrs.is_a?(Hash)
-          write_attribute(:data, multi_json_dump(attrs.merge(data || {})))
+          attrs = data.merge(attrs) if data
+          write_attribute(:data, multi_json_dump(attrs))
         end
 
         def data

--- a/spec/unit/client/active_record/notification_spec.rb
+++ b/spec/unit/client/active_record/notification_spec.rb
@@ -14,7 +14,7 @@ describe Rpush::Client::ActiveRecord::Notification do
   end
   
   it 'allows assignment of many registration IDs from string to parse' do
-    notification.registration_ids = '[a,b]'
+    notification.registration_ids = '["a","b"]'
     expect(notification.registration_ids).to eq %w(a b)
   end
 

--- a/spec/unit/client/active_record/notification_spec.rb
+++ b/spec/unit/client/active_record/notification_spec.rb
@@ -7,6 +7,16 @@ describe Rpush::Client::ActiveRecord::Notification do
     notification.registration_ids = %w(a b)
     expect(notification.registration_ids).to eq %w(a b)
   end
+  
+  it 'allows assignment of many registration IDs from string to split on spaces' do
+    notification.registration_ids = 'a b'
+    expect(notification.registration_ids).to eq %w(a b)
+  end
+  
+  it 'allows assignment of many registration IDs from string to parse' do
+    notification.registration_ids = '[a,b]'
+    expect(notification.registration_ids).to eq %w(a b)
+  end
 
   it 'allows assignment of a single registration ID' do
     notification.registration_ids = 'a'

--- a/spec/unit/notification_shared.rb
+++ b/spec/unit/notification_shared.rb
@@ -16,7 +16,7 @@ shared_examples_for "an Notification subclass" do
       notification.data = { ninjas: 1 }
     end
 
-    it "raises an ArgumentError if something other than a Hash is assigned" do
+    it "raises an ArgumentError if something other than a Hash and String is assigned" do
       expect do
         notification.data = []
       end.to raise_error(ArgumentError, "must be a Hash")
@@ -24,6 +24,11 @@ shared_examples_for "an Notification subclass" do
 
     it "encodes the given Hash as JSON" do
       notification.data = { hi: "mom" }
+      expect(notification.read_attribute(:data)).to eq("{\"hi\":\"mom\"}")
+    end
+	
+    it "encodes the given String as JSON" do
+      notification.data = '{"hi":"mom"}'
       expect(notification.read_attribute(:data)).to eq("{\"hi\":\"mom\"}")
     end
 


### PR DESCRIPTION
I'm trying to solve this issue: https://github.com/rpush/rpush/issues/141
I think rpush should accept and parse strings for data and registration_ids fields because they are saved as string in db. We just have to respect the final format.

This lets ActiveAdmin works correctly as they can treat these fields like simple strings.

I'm new to code sharing on github with pull requests, unit testing etc.
Please don't hit me and guide me ^^
