### PR TITLE
Backwards compatability with ActiveRecord

### DIFF
--- a/lib/generators/templates/rpush_2_0_0_updates.rb
+++ b/lib/generators/templates/rpush_2_0_0_updates.rb
@@ -58,7 +58,7 @@ class Rpush200Updates < ActiveRecord::Migration
 
   def self.adapter_name
     env = (defined?(Rails) && Rails.env) ? Rails.env : 'development'
-    ActiveRecord::Base.configurations[env]['adapter']
+    Hash[ActiveRecord::Base.configurations[env].map { |k,v| [k.to_sym,v] }][:adapter]
   end
 
   def self.postgresql?


### PR DESCRIPTION
The migration didn't work with my version of ActiveRecord because the hash was using symbols instead of strings.