### PR TITLE
Update README.md to make examples more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ app.save!
 ```ruby
 n = Rpush::Gcm::Notification.new
 n.app = Rpush::Gcm::App.find_by_name("android_app")
-n.registration_ids = ["token", "..."]
+n.registration_ids = ["..."]
 n.data = { message: "hi mom!" }
 n.save!
 ```


### PR DESCRIPTION
Most people seem to be confused by the example, where `'token'` is the first element of the `registration_ids` array, and three dots the second element. https://github.com/rpush/rpush/issues/96

For consistency with the iOS example, where the `device_token` is displayed as `'...'`, and to avoid the confusion described in the linked issue, I propose this change.

Thanks for such a great library. It's been a lifesaver.