### PR TITLE
Fix missing requirement 'ostruct' for Ruby 1.9.1

### DIFF
--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'ostruct'
 
 module Rpush
   class << self


### PR DESCRIPTION
Hi! I have project with Ruby 1.9.1 and Rails 4.0.
But rpush gem breaks backward compatibility (due missing``
require 'ostruct'
``statement in configuration.rb).
This pull request contains fix of this issue.