### PR TITLE
Replace find_by_name with find_by in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ app.save!
 
 ```ruby
 n = Rpush::Apns::Notification.new
-n.app = Rpush::Apns::App.find_by_name("ios_app")
+n.app = Rpush::Apns::App.find_by(name: "ios_app")
 n.device_token = "..." # 64-character hex string
 n.alert = "hi mom!"
 n.data = { foo: :bar }
@@ -84,7 +84,7 @@ app.save!
 
 ```ruby
 n = Rpush::Gcm::Notification.new
-n.app = Rpush::Gcm::App.find_by_name("android_app")
+n.app = Rpush::Gcm::App.find_by(name: "android_app")
 n.registration_ids = ["..."]
 n.data = { message: "hi mom!" }
 n.save!
@@ -105,7 +105,7 @@ app.save!
 
 ```ruby
 n = Rpush::Adm::Notification.new
-n.app = Rpush::Adm::App.find_by_name("kindle_app")
+n.app = Rpush::Adm::App.find_by(name: "kindle_app")
 n.registration_ids = ["..."]
 n.data = { message: "hi mom!"}
 n.collapse_key = "Optional consolidationKey"
@@ -125,7 +125,7 @@ app.save!
 
 ```ruby
 n = Rpush::Wpns::Notification.new
-n.app = Rpush::Wpns::App.find_by_name("windows_phone_app")
+n.app = Rpush::Wpns::App.find_by(name: "windows_phone_app")
 n.uri = "http://..."
 n.data = {title:"MyApp", body:"Hello world", param:"user_param1"}
 n.save!


### PR DESCRIPTION
`find_by_name` works with ActiveRecord backend and does not with Mongoid and Redis backends.
`find_by` works with ActiveRecord and Mongoid backends, and does not with Redis (looks like it's not difficult to implement, will try to do it). 

Hope it will improve readme for a little. Thank you.
