### PR TITLE
not able to stop rpush sometimes

### DIFF
--- a/lib/rpush/cli.rb
+++ b/lib/rpush/cli.rb
@@ -35,15 +35,10 @@ module Rpush
 
       STDOUT.write "* Stopping Rpush (pid #{pid})... "
       STDOUT.flush
-      Process.kill('TERM', pid)
 
-      loop do
-        begin
-          Process.getpgid(pid)
-          sleep 0.05
-        rescue Errno::ESRCH
-          break
-        end
+      while (Process.getpgid(pid) rescue false)
+        Process.kill('TERM', pid)
+        sleep 0.1
       end
 
       puts ANSI.green { '✔' }


### PR DESCRIPTION
>>SIGTERM - This signal requests a process to stop running. This signal can be ignored. The process is given time to gracefully shutdown. When a program gracefully shuts down, that means it is given time to save its progress and release resources. In other words, it is not forced to stop. SIGINT is very similar to SIGTERM.

So, "Process.kill('TERM', pid)" sometimes failed and then code will do the loop all the time.

We met this problem for several times during deployment.