### PR TITLE
Remove `param` tag from WNS message.

### DIFF
--- a/lib/rpush/daemon/wns/delivery.rb
+++ b/lib/rpush/daemon/wns/delivery.rb
@@ -158,13 +158,11 @@ module Rpush
         def notification_to_xml
           title = clean_param_string(@notification.data['title']) if @notification.data['title'].present?
           body = clean_param_string(@notification.data['body']) if @notification.data['body'].present?
-          param = clean_param_string(@notification.data['param']) if @notification.data['param'].present?
           "<toast>
             <visual version='1' lang='en-US'>
               <binding template='ToastText02'>
                 <text id='1'>#{title}</text>
                 <text id='2'>#{body}</text>
-                <param>#{param}</param>
               </binding>
             </visual>
           </toast>"


### PR DESCRIPTION
Toast does not show if `param` tag passed. Also it does not exist in documentation https://msdn.microsoft.com/en-us/library/windows/apps/br230849.aspx