### PR TITLE
GCM: fixed raise of unhandled errors

### DIFF
--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -44,7 +44,7 @@ module Rpush
           when 503
             service_unavailable(response)
           else
-            fail Rpush::DeliveryError.new(response.code, @notification.id, Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i])
+            fail Rpush::DeliveryError.new(response.code.to_i, @notification.id, Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i])
           end
         end
 


### PR DESCRIPTION
Fixes unhandled error codes -such as 502-, it should be a fixnum else it throws the following exception:

01 [2015-08-25 11:47:04] [ERROR] Modis::AttributeCoercionError, Received value of type 'String', expected 'Fixnum' for attribute 'error_code'.
01 /var/www/doorbot-web/shared/bundle/ruby/2.0.0/gems/modis-1.4.1/lib/modis/attribute.rb:64:in `error_code='

Thanks!