### PR TITLE
adding content_available to gcm

### DIFF
--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -22,6 +22,7 @@ module Rpush
             }
             json['collapse_key'] = collapse_key if collapse_key
             json['time_to_live'] = expiry if expiry
+            json['content_available'] = content_available if content_available
             json
           end
         end

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -19,6 +19,10 @@ module Rpush
                           :uri, :url_args, :category, :content_available
         end
 
+        def content_available=(content_available)
+          write_attribute(:content_available, content_available)))
+        end
+
         def data=(attrs)
           return unless attrs
           fail ArgumentError, "must be a Hash" unless attrs.is_a?(Hash)

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -12,15 +12,13 @@ module Rpush
 
         belongs_to :app, class_name: 'Rpush::Client::ActiveRecord::App'
 
+        attr_accessor :content_available
+
         if Rpush.attr_accessible_available?
           attr_accessible :badge, :device_token, :sound, :alert, :data, :expiry, :delivered,
                           :delivered_at, :failed, :failed_at, :error_code, :error_description, :deliver_after,
                           :alert_is_json, :app, :app_id, :collapse_key, :delay_while_idle, :registration_ids,
                           :uri, :url_args, :category, :content_available
-        end
-
-        def content_available=(content_available)
-          write_attribute(:content_available, content_available)
         end
 
         def data=(attrs)

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -20,7 +20,7 @@ module Rpush
         end
 
         def content_available=(content_available)
-          write_attribute(:content_available, content_available)))
+          write_attribute(:content_available, content_available)
         end
 
         def data=(attrs)

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -16,7 +16,7 @@ module Rpush
           attr_accessible :badge, :device_token, :sound, :alert, :data, :expiry, :delivered,
                           :delivered_at, :failed, :failed_at, :error_code, :error_description, :deliver_after,
                           :alert_is_json, :app, :app_id, :collapse_key, :delay_while_idle, :registration_ids,
-                          :uri, :url_args, :category
+                          :uri, :url_args, :category, :content_available
         end
 
         def data=(attrs)


### PR DESCRIPTION
Hi,
GCM has a especification to use it with IOS that gem is not following.

https://developers.google.com/cloud-messaging/ios/client

Could I implement this?
Here my suggestion, how could i improve this?