### PR TITLE
Adding content_available to gcm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,3 +244,6 @@ DEPENDENCIES
   sqlite3
   stackprof
   timecop
+
+BUNDLED WITH
+   1.10.3

--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -40,6 +40,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
 
     add_rpush_migration('rpush_2_0_0_updates')
     add_rpush_migration('rpush_2_1_0_updates')
+    add_rpush_migration('rpush_2_5_1_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_2_1_1_updates.rb
+++ b/lib/generators/templates/rpush_2_1_1_updates.rb
@@ -1,0 +1,9 @@
+class Rpush211Updates < ActiveRecord::Migration
+  def self.up
+    add_column :rpush_notifications, :content_available, :boolean, default: false
+  end
+
+  def self.down
+    remove_column :rpush_notifications, :content_available
+  end
+end

--- a/lib/generators/templates/rpush_2_5_1_updates.rb
+++ b/lib/generators/templates/rpush_2_5_1_updates.rb
@@ -1,4 +1,4 @@
-class Rpush211Updates < ActiveRecord::Migration
+class Rpush251Updates < ActiveRecord::Migration
   def self.up
     add_column :rpush_notifications, :content_available, :boolean, default: false
   end

--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -22,6 +22,7 @@ module Rpush
             }
             json['collapse_key'] = collapse_key if collapse_key
             json['time_to_live'] = expiry if expiry
+            json['content_available'] = content_available if content_available
             json
           end
         end

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -16,7 +16,7 @@ module Rpush
           attr_accessible :badge, :device_token, :sound, :alert, :data, :expiry, :delivered,
                           :delivered_at, :failed, :failed_at, :error_code, :error_description, :deliver_after,
                           :alert_is_json, :app, :app_id, :collapse_key, :delay_while_idle, :registration_ids,
-                          :uri, :url_args, :category
+                          :uri, :url_args, :category, :content_available
         end
 
         def data=(attrs)


### PR DESCRIPTION
Hi,
to use GCM for IOS it's necessary set content_available in body message. I make this changes, but I don't know how to make the tests pass (how to set up the relational databases and mongo).

Source: https://developers.google.com/cloud-messaging/ios/client