### PR TITLE
Update WNS instructions with missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ For more documentation on [ADM](https://developer.amazon.com/sdk/adm.html).
 ```ruby
 app = Rpush::Wpns::App.new
 app.name = "windows_phone_app"
+app.client_id = # Get this from your apps dashboard https://dev.windows.com
+app.client_secret = # Get this from your apps dashboard https://dev.windows.com
 app.connections = 1
 app.save!
 ```


### PR DESCRIPTION
Set the `client_id` and `client_secret` where not set. Without them the sample could would not have worked.