### PR TITLE
Add content_available to GCM notifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpush (2.5.0)
+    rpush (2.6.0)
       activesupport
       ansi
       multi_json (~> 1.0)

--- a/Gemfile.rails-3.lock
+++ b/Gemfile.rails-3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpush (2.5.0)
+    rpush (2.6.0)
       activesupport
       ansi
       multi_json (~> 1.0)

--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -40,6 +40,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
 
     add_rpush_migration('rpush_2_0_0_updates')
     add_rpush_migration('rpush_2_1_0_updates')
+    add_rpush_migration('rpush_2_6_0_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_2_6_0_updates.rb
+++ b/lib/generators/templates/rpush_2_6_0_updates.rb
@@ -1,0 +1,10 @@
+class Rpush260Updates < ActiveRecord::Migration
+  def self.up
+    add_column :rpush_notifications, :content_available, :boolean, default: false
+  end
+
+  def self.down
+    remove_column :rpush_notifications, :content_available
+  end
+end
+

--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -22,6 +22,7 @@ module Rpush
             }
             json['collapse_key'] = collapse_key if collapse_key
             json['time_to_live'] = expiry if expiry
+            json['content_available'] = content_available if content_available
             json
           end
         end

--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -16,7 +16,7 @@ module Rpush
           attr_accessible :badge, :device_token, :sound, :alert, :data, :expiry, :delivered,
                           :delivered_at, :failed, :failed_at, :error_code, :error_description, :deliver_after,
                           :alert_is_json, :app, :app_id, :collapse_key, :delay_while_idle, :registration_ids,
-                          :uri, :url_args, :category
+                          :uri, :url_args, :category, :content_available
         end
 
         def data=(attrs)

--- a/lib/rpush/client/mongoid/notification.rb
+++ b/lib/rpush/client/mongoid/notification.rb
@@ -32,6 +32,7 @@ module Rpush
         field :priority, type: Integer
         field :url_args, type: Array
         field :category, type: String
+        field :content_available, type: Boolean, default: false
 
         field :integer_id, type: Integer
         increments :integer_id, model_name: name

--- a/lib/rpush/client/redis/notification.rb
+++ b/lib/rpush/client/redis/notification.rb
@@ -42,6 +42,7 @@ module Rpush
         attribute :priority, :integer
         attribute :url_args, :array
         attribute :category, :string
+        attribute :content_available, :boolean, default: false
 
         def app
           return nil unless app_id

--- a/lib/rpush/version.rb
+++ b/lib/rpush/version.rb
@@ -1,3 +1,3 @@
 module Rpush
-  VERSION = '2.5.0'
+  VERSION = '2.6.0'
 end

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -29,8 +29,9 @@ ActiveRecord::Base.establish_connection(db_config[SPEC_ADAPTER])
 require 'generators/templates/add_rpush'
 require 'generators/templates/rpush_2_0_0_updates'
 require 'generators/templates/rpush_2_1_0_updates'
+require 'generators/templates/rpush_2_6_0_updates'
 
-migrations = [AddRpush, Rpush200Updates, Rpush210Updates]
+migrations = [AddRpush, Rpush200Updates, Rpush210Updates, Rpush260Updates]
 
 unless ENV['TRAVIS']
   migrations.reverse_each do |m|

--- a/spec/unit/client/active_record/gcm/notification_spec.rb
+++ b/spec/unit/client/active_record/gcm/notification_spec.rb
@@ -31,4 +31,9 @@ describe Rpush::Client::ActiveRecord::Gcm::Notification do
     notification.expiry = 100
     expect(notification.as_json['time_to_live']).to eq 100
   end
+
+  it 'includes content_available in the payload' do
+    notification.content_available = true
+    expect(notification.as_json['content_available']).to eq true
+  end
 end if active_record?


### PR DESCRIPTION
Sorry for the two pull requests, now from the correct branch.

Adds `content_available` to GCM notifications. Read more about it [here](https://developers.google.com/cloud-messaging/ios/client#receive_messages_through_the_gcm_apns_interface)