### PR TITLE
Update JRuby to 1.7.23, ignore failed JRuby testruns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,16 +76,20 @@ matrix:
   - rvm: rbx-2.5.8
     gemfile: Gemfile
     env: CLIENT=mongoid
-  - rvm: jruby-1.7.20.1
+  - rvm: jruby-1.7.23
     gemfile: Gemfile
     env: CLIENT=active_record
-  - rvm: jruby-1.7.20.1
+  - rvm: jruby-1.7.23
     gemfile: Gemfile
     env: CLIENT=redis
-  - rvm: jruby-1.7.20.1
+  - rvm: jruby-1.7.23
     gemfile: Gemfile
     env: CLIENT=mongoid
   allow_failures:
     - rvm: 1.9.3
-    - rvm: jruby-1.7.20.1
+    - rvm: jruby-1.7.23
       env: CLIENT=active_record
+    - rvm: jruby-1.7.23
+      env: CLIENT=redis
+    - rvm: jruby-1.7.23
+      env: CLIENT=mongoid


### PR DESCRIPTION
I don't know why, but at some point in the past, more and more JRuby test runs failed. The `bundler` version was a different one, so it might be that.

I know this is not fixing the problem, but I don't know enough at this point to fix this issue. I found out that the `multi_json` gem is not getting installed for jRuby. After explicitly setting it as a dependency in the Gemfile, the next gem was missing, namely `ansi`.

To me, it appears that the runtime dependencies declared in the `rpush.gemspec` file are ignored for JRuby builds. I don't know why. :\

As they don't work, I suggest adding them to `allow_failures` in the `.travis.yml` file until somebody who knows more about this stuff fixes it.