### PR TITLE
Fixed issue where setting the mdm parameter broke to_binary

### DIFF
--- a/lib/rpush/client/active_model/apns/notification.rb
+++ b/lib/rpush/client/active_model/apns/notification.rb
@@ -80,7 +80,7 @@ module Rpush
 
           def priority_for_frame
             # It is an error to use APNS_PRIORITY_IMMEDIATE for a notification that only contains content-available.
-            if as_json['aps'].keys == ['content-available']
+            if as_json['aps'].try(:keys) == ['content-available']
               APNS_PRIORITY_CONSERVE_POWER
             else
               priority || APNS_PRIORITY_IMMEDIATE

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -98,6 +98,11 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'MDM' do
   let(:magic) { 'abc123' }
   let(:notification) { Rpush::Client::ActiveRecord::Apns::Notification.new }
 
+  before do
+    notification.device_token = "a" * 64
+    notification.id = 1234
+  end
+
   it 'includes the mdm magic in the payload' do
     notification.mdm = magic
     expect(notification.as_json).to eq('mdm' => magic)
@@ -107,6 +112,11 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'MDM' do
     notification.alert = "i'm doomed"
     notification.mdm = magic
     expect(notification.as_json.key?('aps')).to be_falsey
+  end
+
+  it 'can be converted to binary' do
+    notification.mdm = magic
+    expect(notification.to_binary).to be_present
   end
 end if active_record?
 


### PR DESCRIPTION
If it's an MDM push, no 'aps' key is present in the json, so the priority_for_frame method failed and prevented the push.  I added a spec that fails without this fix.