### PR TITLE
Add priority to GCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.7.0 (Unreleased)
 
+#### Features
+
+* Added support for GCM priorities. ([#243](https://github.com/rpush/rpush/pull/243))
+
 #### Fixes
 
 * Fixed issue where setting the `mdm` parameter broke `to_binary` for MDM APNs ([#234](https://github.com/rpush/rpush/pull/234))

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ n = Rpush::Gcm::Notification.new
 n.app = Rpush::Gcm::App.find_by_name("android_app")
 n.registration_ids = ["..."]
 n.data = { message: "hi mom!" }
+n.priority = 'high'        # Optional, can be either 'normal' or 'high'
+n.content_available = true # Optional
 n.save!
 ```
 

--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -3,9 +3,14 @@ module Rpush
     module ActiveModel
       module Gcm
         module Notification
+          GCM_PRIORITY_HIGH = Rpush::Client::ActiveModel::Apns::Notification::APNS_PRIORITY_IMMEDIATE
+          GCM_PRIORITY_NORMAL = Rpush::Client::ActiveModel::Apns::Notification::APNS_PRIORITY_CONSERVE_POWER
+          GCM_PRIORITIES = [GCM_PRIORITY_HIGH, GCM_PRIORITY_NORMAL]
+
           def self.included(base)
             base.instance_eval do
               validates :registration_ids, presence: true
+              validates :priority, inclusion: { in: GCM_PRIORITIES }, allow_nil: true
 
               validates_with Rpush::Client::ActiveModel::PayloadDataSizeValidator, limit: 4096
               validates_with Rpush::Client::ActiveModel::RegistrationIdsCountValidator, limit: 1000
@@ -14,16 +19,37 @@ module Rpush
             end
           end
 
+          # This is a hack. The schema defines `priority` to be an integer, but GCM expects a string.
+          # But for users of rpush to have an API they might expect (setting priority to `high`, not 10)
+          # we do a little conversion here.
+          # I'm not happy about it, but this will have to do until I can take a further look.
+          def priority=(priority)
+            case priority
+              when 'high'
+                super(GCM_PRIORITY_HIGH)
+              when 'normal'
+                super(GCM_PRIORITY_NORMAL)
+              else
+                errors.add(:priority, 'must be one of either "normal" or "high"')
+            end
+          end
+
           def as_json(options = nil)
             json = {
-              'registration_ids' => registration_ids,
-              'delay_while_idle' => delay_while_idle,
-              'data' => data
+                'registration_ids' => registration_ids,
+                'delay_while_idle' => delay_while_idle,
+                'data' => data
             }
             json['collapse_key'] = collapse_key if collapse_key
             json['time_to_live'] = expiry if expiry
             json['content_available'] = content_available if content_available
+            json['priority'] = priority_for_notification if priority
             json
+          end
+
+          def priority_for_notification
+            return 'high' if priority == GCM_PRIORITY_HIGH
+            'normal' if priority == GCM_PRIORITY_NORMAL
           end
         end
       end

--- a/spec/unit/client/active_record/gcm/notification_spec.rb
+++ b/spec/unit/client/active_record/gcm/notification_spec.rb
@@ -36,4 +36,23 @@ describe Rpush::Client::ActiveRecord::Gcm::Notification do
     notification.content_available = true
     expect(notification.as_json['content_available']).to eq true
   end
+
+  it 'sets the priority to high when set to high' do
+    notification.priority = 'high'
+    expect(notification.as_json['priority']).to eq 'high'
+  end
+
+  it 'sets the priority to normal when set to normal' do
+    notification.priority = 'normal'
+    expect(notification.as_json['priority']).to eq 'normal'
+  end
+
+  it 'validates the priority is either "normal" or "high"' do
+    notification.priority = 'invalid'
+    expect(notification.errors[:priority]).to eq ['must be one of either "normal" or "high"']
+  end
+
+  it 'excludes the priority if it is not defined' do
+    expect(notification.as_json).not_to have_key 'priority'
+  end
 end if active_record?


### PR DESCRIPTION
It's a bit of a hack, admittedly, but it should do the trick until we wrap our heads around how to integrate more of the modern GCM features without having to constantly adopt rpush, add columns to the database etc.