### PR TITLE
APNS alert content may be longer than 255 chars

### DIFF
--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -41,6 +41,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_2_0_0_updates')
     add_rpush_migration('rpush_2_1_0_updates')
     add_rpush_migration('rpush_2_6_0_updates')
+    add_rpush_migration('rpush_2_7_0_updates')
   end
 
   protected
@@ -48,7 +49,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
   def has_migration?(template)
     migration_dir = File.expand_path('db/migrate')
     self.class.migration_exists?(migration_dir, template)
-   end
+  end
 
   def add_rpush_migration(template)
     self.class.next_template = template

--- a/lib/generators/templates/rpush_2_7_0_updates.rb
+++ b/lib/generators/templates/rpush_2_7_0_updates.rb
@@ -1,0 +1,10 @@
+class Rpush270Updates < ActiveRecord::Migration
+  def self.up
+    change_column :rpush_notifications, :alert, :text
+  end
+
+  def self.down
+    change_column :rpush_notifications, :alert, :string
+  end
+end
+

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -30,8 +30,9 @@ require 'generators/templates/add_rpush'
 require 'generators/templates/rpush_2_0_0_updates'
 require 'generators/templates/rpush_2_1_0_updates'
 require 'generators/templates/rpush_2_6_0_updates'
+require 'generators/templates/rpush_2_7_0_updates'
 
-migrations = [AddRpush, Rpush200Updates, Rpush210Updates, Rpush260Updates]
+migrations = [AddRpush, Rpush200Updates, Rpush210Updates, Rpush260Updates, Rpush270Updates]
 
 unless ENV['TRAVIS']
   migrations.reverse_each do |m|

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -23,6 +23,17 @@ describe Rpush::Client::ActiveRecord::Apns::Notification do
     expect(notification.errors[:base].include?("APN notification cannot be larger than 2048 bytes. Try condensing your alert and device attributes.")).to be_truthy
   end
 
+  it "should store long alerts" do
+    notification.app = app
+    notification.device_token = "a" * 64
+    notification.alert = "*" * 300
+    expect(notification.valid?).to be_truthy
+
+    notification.save!
+    notification.reload
+    expect(notification.alert).to eq("*" * 300)
+  end
+
   it "should default the sound to 'default'" do
     expect(notification.sound).to eq('default')
   end


### PR DESCRIPTION
The Apns::Notification binary size validation is allowing messages, that cannot be saved in the DB, since they are to long. This patch adds a migration to change the alert column to type text and adds a spec exposing the behaviour.

Fixes #235