### PR TITLE
Make synchronizer aware of GCM and WNS apps

### DIFF
--- a/spec/functional/synchronization_spec.rb
+++ b/spec/functional/synchronization_spec.rb
@@ -15,6 +15,8 @@ describe 'Synchronization' do
   before do
     app.name = 'test'
     app.auth_key = 'abc123'
+    app.client_id = 'client'
+    app.client_secret = 'secret'
     app.connections = 2
     app.certificate = TEST_CERT_WITH_PASSWORD
     app.password = 'fubar'
@@ -64,5 +66,32 @@ describe 'Synchronization' do
 
     running_app = Rpush::Daemon::AppRunner.app_with_id(app.id)
     expect(running_app.environment).to eql('production')
+  end
+
+  it 'restarts an app when the auth_key is changed' do
+    app.auth_key = '321cba'
+    app.save!
+    Rpush.sync
+
+    running_app = Rpush::Daemon::AppRunner.app_with_id(app.id)
+    expect(running_app.auth_key).to eql('321cba')
+  end
+
+  it 'restarts an app when the client_id is changed' do
+    app.client_id = 'another_client'
+    app.save!
+    Rpush.sync
+
+    running_app = Rpush::Daemon::AppRunner.app_with_id(app.id)
+    expect(running_app.client_id).to eql('another_client')
+  end
+
+  it 'restarts an app when the client_secret is changed' do
+    app.client_secret = 'another_secret'
+    app.save!
+    Rpush.sync
+
+    running_app = Rpush::Daemon::AppRunner.app_with_id(app.id)
+    expect(running_app.client_secret).to eql('another_secret')
   end
 end


### PR DESCRIPTION
The synchronizer now also restarts an app if:
* the auth_key changed (GCM)
* the client_id and/or client_secret changed (WNS)