### PR TITLE
ERROR: "command not found: rpush" FIX: Bundle exec prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Initialize Rpush into your project. **Rails will be detected automatically.**
 
 ```sh
 $ cd /path/to/project
-$ rpush init
+$ bundle
+$ bundle exec rpush init
 ```
 
 ### Create an App & Notification


### PR DESCRIPTION
Ran into "command not found: rpush" error, and it took me a quarter of hour to figure out why. Thought I'd save some time to people using a different ruby version like me and running into the same problem.
Feel free to reject the PR if I'm just an ignorant newbie who should know this stuff already.