### PR TITLE
`registration_ids` should only be used for multicast messaging

### DIFF
--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -36,10 +36,16 @@ module Rpush
 
           def as_json(options = nil)
             json = {
-                'registration_ids' => registration_ids,
                 'delay_while_idle' => delay_while_idle,
                 'data' => data
             }
+
+            if registration_ids.size == 1
+              json['to'] = registration_ids.first
+            else
+              json['registration_ids'] = registration_ids
+            end
+
             json['collapse_key'] = collapse_key if collapse_key
             json['content_available'] = content_available if content_available
             json['notification'] = notification if notification


### PR DESCRIPTION
According to

https://developers.google.com/cloud-messaging/http-server-ref#notification-payload-support

`to (String)`
This parameter specifies the recipient of a message.
The value must be a registration token, notification key, or topic.

`registration_ids (String array)`
Use this parameter only for multicast messaging, not for single recipients. Multicast messages (sending to more than 1 registration tokens) are allowed using HTTP JSON format only.

I think this payload should be more appropriate.
