### PR TITLE
Switch GCM with FCM server endpoint

### DIFF
--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -1,12 +1,12 @@
 module Rpush
   module Daemon
     module Gcm
-      # http://developer.android.com/guide/google/gcm/gcm.html#response
+      # https://firebase.google.com/docs/cloud-messaging/server
       class Delivery < Rpush::Daemon::Delivery
         include MultiJsonHelper
 
-        host = 'https://gcm-http.googleapis.com'
-        GCM_URI = URI.parse("#{host}/gcm/send")
+        host = 'https://fcm.googleapis.com'
+        FCM_URI = URI.parse("#{host}/fcm/send")
         UNAVAILABLE_STATES = %w(Unavailable InternalServerError)
         INVALID_REGISTRATION_ID_STATES = %w(InvalidRegistration MismatchSenderId NotRegistered InvalidPackageName)
 
@@ -142,10 +142,10 @@ module Rpush
         end
 
         def do_post
-          post = Net::HTTP::Post.new(GCM_URI.path, 'Content-Type'  => 'application/json',
+          post = Net::HTTP::Post.new(FCM_URI.path, 'Content-Type'  => 'application/json',
                                                    'Authorization' => "key=#{@notification.app.auth_key}")
           post.body = @notification.as_json.to_json
-          @http.request(GCM_URI, post)
+          @http.request(FCM_URI, post)
         end
       end
 


### PR DESCRIPTION
I purposedly left all comments, classes, debug output etc untouched,
because other than the server endpoint, users of the library still use
GCM and not FCM.

Renaming everything would break the API and thus require a version 3.

For reference, see:
https://developers.google.com/cloud-messaging/android/android-migrate-fcm#update_server_endpoints