### PR TITLE
Additional 2.8.0 release preparations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,15 +82,6 @@ matrix:
   - rvm: 2.3.0
     gemfile: Gemfile.rails-3
     env: CLIENT=active_record
-  - rvm: rbx-2.5.8
-    gemfile: Gemfile
-    env: CLIENT=active_record
-  - rvm: rbx-2.5.8
-    gemfile: Gemfile
-    env: CLIENT=redis
-  - rvm: rbx-2.5.8
-    gemfile: Gemfile
-    env: CLIENT=mongoid
   - rvm: jruby-1.7.23
     gemfile: Gemfile
     env: CLIENT=active_record
@@ -122,4 +113,13 @@ matrix:
     - rvm: jruby-9.0.4.0
       env: CLIENT=redis
     - rvm: jruby-9.0.4.0
+      env: CLIENT=mongoid
+    - rvm: rbx-2.5.8
+      gemfile: Gemfile
+      env: CLIENT=active_record
+    - rvm: rbx-2.5.8
+      gemfile: Gemfile
+      env: CLIENT=redis
+    - rvm: rbx-2.5.8
+      gemfile: Gemfile
       env: CLIENT=mongoid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport
       ansi
       multi_json (~> 1.0)
-      net-http-persistent
+      net-http-persistent (~> 2.9)
       railties
       thor (>= 0.18.1, < 2.0)
 
@@ -250,4 +250,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.3.0)
-    redis (3.3.1)
+    redis (3.2.2)
     rpush-mongoid (0.1.0)
       mongoid (~> 4.0.0)
       mongoid-autoinc (~> 4.0.0)

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'multi_json', '~> 1.0'
-  s.add_runtime_dependency 'net-http-persistent'
+  s.add_runtime_dependency 'net-http-persistent', '~> 2.9'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'


### PR DESCRIPTION
- ignore travis rbx errors (rvm rbx installation fails on travis)
- change redis version back to 3.2.2
- lock net-http-persistent to 2.9.x, 3.0.0 has breaking changes