### PR TITLE
Fix Net::Http::Persistent initializer

### DIFF
--- a/lib/rpush/daemon/dispatcher/http.rb
+++ b/lib/rpush/daemon/dispatcher/http.rb
@@ -5,7 +5,7 @@ module Rpush
         def initialize(app, delivery_class, _options = {})
           @app = app
           @delivery_class = delivery_class
-          @http = Net::HTTP::Persistent.new('rpush')
+          @http = Net::HTTP::Persistent.new(name: 'rpush')
         end
 
         def dispatch(payload)


### PR DESCRIPTION
After upgrading to `rpush version 2.7.0`, the [Net::HTTP::Persistent initializer](https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L505) does not work anymore.
```sh
2.3.1 :001 > require 'net/http/persistent'
 => true
2.3.1 :002 > @http = Net::HTTP::Persistent.new('rpush')
ArgumentError: wrong number of arguments (given 1, expected 0)
	from /Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:505:in `initialize'
	from (irb):2:in `new'
	from (irb):2
	from /Users/mujkic/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```

**Rpush backtrace:**
```json
{  
   "level":"error",
   "rpush":{  
      "action":"error",
      "error":{  
         "exception":"ArgumentError",
         "message":"wrong number of arguments (given 1, expected 0)",
         "trace":[  
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:505:in `initialize'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/dispatcher/http.rb:8:in `new'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/dispatcher/http.rb:8:in `initialize'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/service_config_methods.rb:33:in `new'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/service_config_methods.rb:33:in `new_dispatcher'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:174:in `new_dispatcher_loop'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `block in start_dispatchers'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `times'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `start_dispatchers'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:31:in `start_app'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/synchronizer.rb:18:in `sync_app'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/synchronizer.rb:9:in `block in sync'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/activerecord-4.2.4/lib/active_record/relation/delegation.rb:46:in `each'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/activerecord-4.2.4/lib/active_record/relation/delegation.rb:46:in `each'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/synchronizer.rb:9:in `sync'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/push.rb:7:in `push'",
            "(irb):7:in `fcm_push'",
            "(irb):10:in `irb_binding'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `eval'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `evaluate'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/context.rb:380:in `evaluate'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:489:in `block (2 levels) in eval_input'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:623:in `signal_status'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:486:in `block in eval_input'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/ruby-lex.rb:246:in `block (2 levels) in each_top_level_statement'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/ruby-lex.rb:232:in `loop'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/ruby-lex.rb:232:in `block in each_top_level_statement'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/ruby-lex.rb:231:in `catch'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb/ruby-lex.rb:231:in `each_top_level_statement'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:485:in `eval_input'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:395:in `block in start'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:394:in `catch'",
            "/Users/mujkic/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/irb.rb:394:in `start'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/railties-4.2.4/lib/rails/commands/console.rb:110:in `start'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/railties-4.2.4/lib/rails/commands/console.rb:9:in `start'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:68:in `console'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:39:in `run_command!'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/railties-4.2.4/lib/rails/commands.rb:17:in `<top (required)>'",
            "bin/rails:8:in `require'",
            "bin/rails:8:in `<main>'"
         ]
      }
   },
   "request_id":"84211",
   "source":"Communication-service Console",
   "tags":[  

   ],
   "@timestamp":"2016-10-23T09:33:01.238Z",
   "@version":"1"
}{  
   "level":"error",
   "rpush":{  
      "action":"error",
      "error":{  
         "exception":"ArgumentError",
         "message":"wrong number of arguments (given 1, expected 0)",
         "trace":[  
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:505:in `initialize'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/dispatcher/http.rb:8:in `new'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/dispatcher/http.rb:8:in `initialize'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/service_config_methods.rb:33:in `new'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/service_config_methods.rb:33:in `new_dispatcher'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:174:in `new_dispatcher_loop'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `block in start_dispatchers'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `times'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:101:in `start_dispatchers'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:31:in `start_app'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:25:in `start_app_with_id'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:17:in `block in enqueue'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:16:in `each'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/app_runner.rb:16:in `enqueue'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/feeder.rb:58:in `enqueue_notifications'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/feeder.rb:43:in `feed_all'",
            "/Users/mujkic/.rvm/gems/ruby-2.3.1@communication-service/gems/rpush-2.7.0/lib/rpush/daemon/feeder.rb:11:in `block in start'"
         ]
      }
   },
   "request_id":null,
   "source":"Communication-service Console",
   "tags":[  

   ],
   "@timestamp":"2016-10-23T09:33:01.266Z",
   "@version":"1"
}
```