### PR TITLE
Run ApnsFeedback only on Apns apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * ~~~Lock `net-http-persistent` dependency to `< 3`. See also [#306](https://github.com/rpush/rpush/issues/306) for more details. (by [@amaierhofer](https://github.com/amaierhofer))~~~
 * Fix `net-http-persistent` initializer to support version 2.x as well as 3.x. ([#309](https://github.com/rpush/rpush/pull/309) by [@amirmujkic](https://github.com/amirmujkic))
+* Fixed Rpush::ApnsFeedback being run on every application type when using Redis. ([#318](https://github.com/rpush/rpush/pull/318) by [@robertasg](https://github.com/robertasg))
 
 ## 2.7.0 (February 9, 2016)
 

--- a/lib/rpush/apns_feedback.rb
+++ b/lib/rpush/apns_feedback.rb
@@ -4,6 +4,10 @@ module Rpush
     Rpush::Daemon.common_init
 
     Rpush::Apns::App.all.each do |app|
+      # Redis stores every App type on the same namespace, hence the
+      # additional filtering
+      next unless app.service_name == 'apns'
+
       receiver = Rpush::Daemon::Apns::FeedbackReceiver.new(app)
       receiver.check_for_feedback
     end

--- a/spec/unit/apns_feedback_spec.rb
+++ b/spec/unit/apns_feedback_spec.rb
@@ -1,7 +1,14 @@
 require 'unit_spec_helper'
 
 describe Rpush, 'apns_feedback' do
-  let!(:app) { Rpush::Apns::App.create!(name: 'test', environment: 'production', certificate: TEST_CERT) }
+  let!(:apns_app) do
+    Rpush::Apns::App.create!(name: 'test', environment: 'production', certificate: TEST_CERT)
+  end
+
+  let!(:gcm_app) do
+    Rpush::Gcm::App.create!(name: 'MyApp', auth_key: 'abc123')
+  end
+
   let(:receiver) { double(check_for_feedback: nil) }
 
   before do
@@ -14,7 +21,7 @@ describe Rpush, 'apns_feedback' do
   end
 
   it 'checks feedback for each app' do
-    expect(Rpush::Daemon::Apns::FeedbackReceiver).to receive(:new).with(app).and_return(receiver)
+    expect(Rpush::Daemon::Apns::FeedbackReceiver).to receive(:new).with(apns_app).and_return(receiver)
     expect(receiver).to receive(:check_for_feedback)
     Rpush.apns_feedback
   end


### PR DESCRIPTION
Currently, ApnsFeedback tries running on every added application, including GCM for example. This results in a crash due to incompatible interfaces.