### PR TITLE
changed migration to remove default sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Make synchronizer aware of GCM and WNS apps ([#254](https://github.com/rpush/rpush/pull/254) by [@wouterh](https://github.com/wouterh))
 * Precise after init commit msg ([#266](https://github.com/rpush/rpush/pull/266) by [@azranel](https://github.com/azranel))
 * Use new GCM endpoint ([#303](https://github.com/rpush/rpush/pull/303) by [@aried3r](https://github.com/aried3r))
+* Remove sound default value
 
 #### Bugfixes
 

--- a/lib/generators/templates/rpush_3_0_0_updates.rb
+++ b/lib/generators/templates/rpush_3_0_0_updates.rb
@@ -1,9 +1,11 @@
 class Rpush300Updates < ActiveRecord::Migration
   def self.up
     add_column :rpush_notifications, :mutable_content, :boolean, default: false
+    change_column :rpush_notifications, :sound, :string, default: nil
   end
 
   def self.down
     remove_column :rpush_notifications, :mutable_content
+    change_column :rpush_notifications, :sound, :string, default: 'default'
   end
 end

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -48,6 +48,7 @@ describe 'APNs http2 adapter' do
   def create_notification
     notification = Rpush::Apns2::Notification.new
     notification.app = app
+    notification.sound = 'default'
     notification.alert = 'test'
     notification.device_token = fake_device_token
     notification.data = notification_data

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -34,8 +34,8 @@ describe Rpush::Client::ActiveRecord::Apns::Notification do
     expect(notification.alert).to eq("*" * 300)
   end
 
-  it "should default the sound to 'default'" do
-    expect(notification.sound).to eq('default')
+  it "should default the sound to nil" do
+    expect(notification.sound).to be_nil
   end
 
   it "should default the expiry to 1 day" do


### PR DESCRIPTION
According to official documentation the sound key must not be included
when sending silent push.