### PR TITLE
Update APNS App creation example's environment name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If this is your first time using the APNs, you will need to generate SSL certifi
 app = Rpush::Apns::App.new
 app.name = "ios_app"
 app.certificate = File.read("/path/to/sandbox.pem")
-app.environment = "sandbox" # APNs environment.
+app.environment = "development" # APNs environment.
 app.password = "certificate password"
 app.connections = 1
 app.save!


### PR DESCRIPTION
* The APNS environment names in the latest code are "development" and "production" (as seen here: https://github.com/rpush/rpush/blob/master/lib/rpush/daemon/dispatcher/apns_http2.rb#L8), so using "sandbox" will fail with a Bad URI error. Changes the README's example to use "development" so that it'll work with the latest code.