### PR TITLE
Apns (http2) performance fix - use batches

### DIFF
--- a/lib/rpush/daemon.rb
+++ b/lib/rpush/daemon.rb
@@ -106,9 +106,7 @@ module Rpush
     end
 
     def self.shutdown_lock
-      return @shutdown_lock if @shutdown_lock
-      @shutdown_lock = Mutex.new
-      @shutdown_lock
+      @shutdown_lock ||= Mutex.new
     end
 
     def self.common_init

--- a/lib/rpush/daemon/apns2.rb
+++ b/lib/rpush/daemon/apns2.rb
@@ -3,6 +3,7 @@ module Rpush
     module Apns2
       extend ServiceConfigMethods
 
+      batch_deliveries true
       dispatcher :apns_http2
     end
   end

--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -21,7 +21,7 @@ module Rpush
         end
 
         def dispatch(payload)
-          @delivery_class.new(@app, @client, payload.batch, payload.notification).perform
+          @delivery_class.new(@app, @client, payload.batch).perform
         end
 
         def cleanup


### PR DESCRIPTION
Performance is increased because of:
- now we prepare batch of requests and send them at once, instead of sending each Notification separately.
- now we use multi-threading to process requests concurrently 

Overall, on a 5000 notifications with a batch size of 2024, sending time reduced from ~1500 seconds to 10 seconds.