### PR TITLE
Apns2 - content-available field missing fix

### DIFF
--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -101,19 +101,7 @@ module Rpush
         end
 
         def prepare_body(notification)
-          aps = {}
-
-          primary_fields = [:alert, :badge, :sound, :category,
-            'content-available', 'url-args']
-          primary_fields.each do |primary_field|
-            field_value = notification.send(primary_field.to_s.underscore.to_sym)
-            next unless field_value
-
-            aps[primary_field] = field_value
-          end
-
-          hash = { aps: aps }
-          hash.merge!(notification_data(notification).except(HTTP2_HEADERS_KEY) || {})
+          hash = notification.as_json.except(HTTP2_HEADERS_KEY)
           JSON.dump(hash).force_encoding(Encoding::BINARY)
         end
 

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -51,6 +51,7 @@ describe 'APNs http2 adapter' do
     notification.alert = 'test'
     notification.device_token = fake_device_token
     notification.data = notification_data
+    notification.content_available = 1
     notification.save!
     notification
   end
@@ -63,7 +64,7 @@ describe 'APNs http2 adapter' do
       .with(
         :post,
         "/3/device/#{fake_device_token}",
-        { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\"}}",
+        { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\",\"content-available\":1}}",
           headers: {} }
       )
       .and_return(fake_http2_request)
@@ -91,8 +92,8 @@ describe 'APNs http2 adapter' do
         .with(
           :post,
           "/3/device/#{fake_device_token}",
-          { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\"},"\
-                  "\"some_field\":\"some value\"}",
+          { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\","\
+                  "\"content-available\":1},\"some_field\":\"some value\"}",
             headers: { 'apns-topic' => bundle_id }
           }
         ).and_return(fake_http2_request)


### PR DESCRIPTION
Pure bug. Changed method has been taking control of body creating, while it should be Notification entity responsibility.

Because of that, `content-available` and some other fields were not transferred to APNS correctly.