### PR TITLE
[APNS2] Notification doesn't change its status fix

### DIFF
--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -21,8 +21,6 @@ module Rpush
 
           # Send all preprocessed requests at once
           @client.join
-
-          @batch.mark_all_delivered
         rescue SocketError => error
           mark_batch_retryable(Time.now + 10.seconds, error)
           raise
@@ -58,8 +56,6 @@ module Rpush
           http_request.on(:close) { handle_response(notification, response) }
 
           @client.call_async(http_request)
-
-          @batch.notification_processed
         end
 
         def handle_response(notification, response)

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -59,6 +59,14 @@ describe 'APNs http2 adapter' do
   it 'delivers a notification successfully' do
     notification = create_notification
 
+    thread = nil
+    expect(fake_http2_request).
+      to receive(:on).with(:close) { |&block|
+        # imitate HTTP2 delay
+        thread = Thread.new { sleep(0.01); block.call }
+      }
+    expect(fake_client).to receive(:join) { thread.join }
+
     expect(fake_client)
       .to receive(:prepare_request)
       .with(


### PR DESCRIPTION
Fixed the bug that caused notifications to be saved before their status has been changed to some (delivered/failed).

```ruby
def prepare_async_post(notification)
  # ... prepare single request to APNS

  # [Wrong] 
  # This line calls `complete` as soon as the last notification
  # has been marked as processed
  # But on this stage we didn't send any request yet
  # (send all at once with `@client.join`)
  # So notifications have been marked as processed & have been saved without any status
  # and we never return to it anymore
  @batch.notification_processed
end
```
```ruby
def perform
  # ...prepare requests for all notifications in the batch...
  # ... send them at once ...
  @client.join
  # [Wrong] Every notification status updates independently,
  # since each has it's own response
  @batch.mark_all_delivered
end
