### PR TITLE
[APNS2] Retry delivery on networking errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'database_cleaner'
 gem 'timecop'
 gem 'rpush-redis', '0.4.1'
 gem 'rpush-mongoid', '0.1.0'
-gem 'net-http2', '0.14.0'
+gem 'net-http2'
 
 platform :mri do
   gem 'cane'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,8 +132,8 @@ GEM
     multi_json (1.12.1)
     mysql2 (0.4.4)
     net-http-persistent (2.9.4)
-    net-http2 (0.14.0)
-      http-2 (~> 0.8.2)
+    net-http2 (0.15.0)
+      http-2 (= 0.8.2)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -240,7 +240,7 @@ DEPENDENCIES
   jdbc-postgres
   jruby-openssl
   mysql2
-  net-http2 (= 0.14.0)
+  net-http2
   pg
   rails (~> 4.2)
   rake

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -6,7 +6,8 @@ describe 'APNs http2 adapter' do
       prepare_request: fake_http2_request,
       close:           'ok',
       call_async:      'ok',
-      join:            'ok'
+      join:            'ok',
+      on:              'ok'
     )
   }
   let(:app) { create_app }


### PR DESCRIPTION
Net/Http2 gem processes delivery in a separate thread.
When it dies, it crashes the whole Rpush process,
which isn't intended.

There's a way to callback network errors.