### PR TITLE
[APNS2] Set default timeout for async http2 requests

### DIFF
--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -228,4 +228,32 @@ describe 'APNs http2 adapter' do
       end
     end
   end
+
+  context 'when one of notifications requests timed out' do
+    it 'delivers one notification successfully, and retries timed out one' do
+      notification1, notification2 = create_notification, create_notification
+
+      expect(fake_client).to receive(:join) { raise(Timeout::Error) }
+      expect(fake_http2_request).to receive(:on).with(:close)
+        .exactly(2).times.and_return(nil)
+
+      expect(fake_client)
+        .to receive(:prepare_request)
+        .with(
+          :post,
+          "/3/device/#{fake_device_token}",
+          { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\",\"content-available\":1}}",
+            headers: {} }
+        )
+        .and_return(fake_http2_request)
+
+      expect(notification1.delivered).to be_falsey
+      expect(notification2.delivered).to be_falsey
+
+      Rpush.push
+
+      expect(notification1.reload.retries).to be > 0
+      expect(notification2.reload.retries).to be > 0
+    end
+  end
 end


### PR DESCRIPTION
**Note:** _that's not a perfect solution, but to do it properly net-http2 gem is required to be updated. There's the [issue](https://github.com/ostinelli/net-http2/issues/19) opened, but it has no estimates._ 

We found another issue with delivering apns notifications via http2. Since async requests have no built-in timeout, if any of notifications stucks, the entire batch waits for it (`@client.join`), and it may take up to few hours with a SockerError at the end.

To avoid that, we introduce timeout for the batch. Notifications will be still delivered in parallel using HTTP2 async streams, but since rpush saves notifications statuses once after delivery of entire batch is completed, we have to wait and retry some notifications that have been failed by timeout and allow further notifications to be processed with a minimal delay.