### PR TITLE
Reconnect on AR ConnectionNotEstablished

### DIFF
--- a/lib/rpush/daemon/store/active_record/reconnectable.rb
+++ b/lib/rpush/daemon/store/active_record/reconnectable.rb
@@ -22,7 +22,8 @@ module Rpush
         module Reconnectable
           ADAPTER_ERRORS = [::ActiveRecord::StatementInvalid, PGError, PG::Error,
                             Mysql::Error, Mysql2::Error, ::ActiveRecord::JDBCError,
-                            SQLite3::Exception, ::ActiveRecord::ConnectionTimeoutError]
+                            SQLite3::Exception, ::ActiveRecord::ConnectionTimeoutError,
+                            ::ActiveRecord::ConnectionNotEstablished]
 
           def with_database_reconnect_and_retry
             ::ActiveRecord::Base.connection_pool.with_connection do

--- a/lib/rpush/daemon/store/active_record/reconnectable.rb
+++ b/lib/rpush/daemon/store/active_record/reconnectable.rb
@@ -20,10 +20,17 @@ module Rpush
     module Store
       class ActiveRecord
         module Reconnectable
-          ADAPTER_ERRORS = [::ActiveRecord::StatementInvalid, PGError, PG::Error,
-                            Mysql::Error, Mysql2::Error, ::ActiveRecord::JDBCError,
-                            SQLite3::Exception, ::ActiveRecord::ConnectionTimeoutError,
-                            ::ActiveRecord::ConnectionNotEstablished]
+          ADAPTER_ERRORS = [
+              ::ActiveRecord::ConnectionNotEstablished,
+              ::ActiveRecord::ConnectionTimeoutError,
+              ::ActiveRecord::JDBCError,
+              ::ActiveRecord::StatementInvalid,
+              Mysql::Error,
+              Mysql2::Error,
+              PG::Error,
+              PGError,
+              SQLite3::Exception
+          ]
 
           def with_database_reconnect_and_retry
             ::ActiveRecord::Base.connection_pool.with_connection do

--- a/spec/unit/daemon/store/active_record/reconnectable_spec.rb
+++ b/spec/unit/daemon/store/active_record/reconnectable_spec.rb
@@ -106,6 +106,15 @@ describe Rpush::Daemon::Store::ActiveRecord::Reconnectable do
     end
   end
 
+  context "should not reconnect on" do
+    let(:error) { ActiveRecord::ActiveRecordError.new }
+
+    it "ActiveRecord::ActiveRecordError" do
+      expect(ActiveRecord::Base).not_to receive(:establish_connection)
+      expect { test_doubles.each(&:perform) }.to raise_error(ActiveRecord::ActiveRecordError)
+    end
+  end
+
   context "when the reconnection attempt is not successful" do
     before do
       class << Rpush::Client::ActiveRecord::Notification

--- a/spec/unit/daemon/store/active_record/reconnectable_spec.rb
+++ b/spec/unit/daemon/store/active_record/reconnectable_spec.rb
@@ -85,6 +85,27 @@ describe Rpush::Daemon::Store::ActiveRecord::Reconnectable do
     test_doubles.each(&:perform)
   end
 
+  context "should reconnect on" do
+    [
+        ::ActiveRecord::ConnectionNotEstablished,
+        ::ActiveRecord::ConnectionTimeoutError,
+        ::ActiveRecord::JDBCError,
+        ::ActiveRecord::StatementInvalid,
+        Mysql::Error,
+        Mysql2::Error,
+        PG::Error,
+        PGError,
+        SQLite3::Exception
+    ].each do |error_class|
+      let(:error) { error_class.new }
+
+      it error_class.name do
+        expect(ActiveRecord::Base).to receive(:establish_connection)
+        test_doubles.each(&:perform)
+      end
+    end
+  end
+
   context "when the reconnection attempt is not successful" do
     before do
       class << Rpush::Client::ActiveRecord::Notification


### PR DESCRIPTION
Sometimes we get `ActiveRecord::ConnectionNotEstablished` errors on our production system.
If this happens, Rpush does not try to reconnect to the database, and the currently processed notifications batch fails.

This pull request adds `ActiveRecord::ConnectionNotEstablished` to the list of reconnectable errors.