### PR TITLE
Update Modis to 1.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,13 +53,13 @@ GEM
     erubis (2.7.0)
     hiredis (0.6.1)
     http-2 (0.8.2)
-    i18n (0.8.4)
+    i18n (0.8.6)
     json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.2.0)
-    minitest (5.10.2)
-    modis (1.4.1)
+    minitest (5.10.3)
+    modis (1.4.2)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       connection_pool (>= 2)
@@ -98,7 +98,7 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
-    redis (3.3.3)
+    redis (4.0.0)
     rpush-redis (0.4.1)
       modis (~> 1.4, >= 1.4.1)
     rspec (3.4.0)
@@ -145,7 +145,7 @@ DEPENDENCIES
   cane
   codeclimate-test-reporter
   database_cleaner
-  modis (= 1.4.1)
+  modis (= 1.4.2)
   mysql2
   pg
   rake

--- a/lib/rpush/client/redis.rb
+++ b/lib/rpush/client/redis.rb
@@ -41,3 +41,10 @@ require 'rpush/client/redis/wns/badge_notification'
 Modis.configure do |config|
   config.namespace = :rpush
 end
+
+# Prevent diverging Redis namespaces for subclasses as introduced by Modis 1.4.2
+Rpush::Client::Redis::Notification.subclasses.each do |notification_class|
+  notification_class.class_eval do
+    self.namespace = Rpush::Client::Redis::Notification.namespace
+  end
+end

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'stackprof'
-  s.add_development_dependency 'modis', '1.4.1'
+  s.add_development_dependency 'modis', '1.4.2'
   s.add_development_dependency 'rpush-redis', '0.4.1'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
As documented in [#372](https://github.com/rpush/rpush/issues/372) the notifications namespace of the subclasses had changed, preventing them from being delivered.