### PR TITLE
better error message for error 8

### DIFF
--- a/lib/rpush/daemon/dispatcher/apns_tcp.rb
+++ b/lib/rpush/daemon/dispatcher/apns_tcp.rb
@@ -15,7 +15,7 @@ module Rpush
           5 => 'Missing token size',
           6 => 'Missing topic size',
           7 => 'Missing payload size',
-          8 => 'Invalid token',
+          8 => 'Invalid device token',
           10 => 'APNs closed connection (possible maintenance)',
           255 => 'None (unknown error)'
         }


### PR DESCRIPTION
according to https://github.com/node-apn/node-apn/issues/135 it's an invalid device token ... since we deal with lots of tokens that should make debugging faster ...

@aried3r 