### PR TITLE
Add sandbox URL to ApnsHttp2 dispatcher

### DIFF
--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -5,7 +5,8 @@ module Rpush
 
         URLS = {
           production: 'https://api.push.apple.com:443',
-          development: 'https://api.development.push.apple.com:443'
+          development: 'https://api.development.push.apple.com:443',
+          sandbox: 'https://api.development.push.apple.com:443'
         }
 
         DEFAULT_TIMEOUT = 60


### PR DESCRIPTION
Was getting `URI::InvalidURIError, bad URI(is not URI?)` when trying to send Apns2 notifications with `app.environment` set to `sandbox`.