### PR TITLE
reflect gcm deprecation

### DIFF
--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -37,7 +37,6 @@ module Rpush
           def as_json(options = nil)
             json = {
                 'registration_ids' => registration_ids,
-                'delay_while_idle' => delay_while_idle,
                 'data' => data
             }
             json['collapse_key'] = collapse_key if collapse_key

--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -36,7 +36,7 @@ module Rpush
           when 200
             ok(response)
           when 400
-            bad_request
+            bad_request(response)
           when 401
             unauthorized
           when 500
@@ -100,14 +100,15 @@ module Rpush
         end
 
         def create_new_notification(response, unavailable_idxs)
-          attrs = { 'app_id' => @notification.app_id, 'collapse_key' => @notification.collapse_key, 'delay_while_idle' => @notification.delay_while_idle }
+          attrs = { 'app_id' => @notification.app_id, 'collapse_key' => @notification.collapse_key }
           registration_ids = @notification.registration_ids.values_at(*unavailable_idxs)
           Rpush::Daemon.store.create_gcm_notification(attrs, @notification.data,
                                                       registration_ids, deliver_after_header(response), @notification.app)
         end
 
-        def bad_request
-          fail Rpush::DeliveryError.new(400, @notification.id, 'GCM failed to parse the JSON request. Possibly an Rpush bug, please open an issue.')
+        def bad_request(response)
+          # due to gcm > fcm update
+          fail Rpush::DeliveryError.new(400, @notification.id, response.inspect)
         end
 
         def unauthorized

--- a/spec/unit/daemon/gcm/delivery_spec.rb
+++ b/spec/unit/daemon/gcm/delivery_spec.rb
@@ -40,9 +40,9 @@ describe Rpush::Daemon::Gcm::Delivery do
     end
 
     it 'creates a new notification for the unavailable devices' do
-      notification.update_attributes(registration_ids: %w(id_0 id_1 id_2), data: { 'one' => 1 }, collapse_key: 'thing', delay_while_idle: true)
+      notification.update_attributes(registration_ids: %w(id_0 id_1 id_2), data: { 'one' => 1 }, collapse_key: 'thing')
       allow(response).to receive_messages(header: { 'retry-after' => 10 })
-      attrs = { 'collapse_key' => 'thing', 'delay_while_idle' => true, 'app_id' => app.id }
+      attrs = { 'collapse_key' => 'thing', 'app_id' => app.id }
       expect(store).to receive(:create_gcm_notification).with(attrs, notification.data,
                                                               %w(id_0 id_2), now + 10.seconds, notification.app)
       perform_with_rescue


### PR DESCRIPTION
Due to update of gcm to fcm, delay_while_idle is not supported anymore (2016.11.15)
Causing JSON parse error for rpush notifications. Deleted related portions.