### PR TITLE
Add support for Pushy service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Rpush aims to be the *de facto* gem for sending push notifications in Ruby. Its 
   * [**Firebase Cloud Messaging**](#firebase-cloud-messaging) (used to be Google Cloud Messaging)
   * [**Amazon Device Messaging**](#amazon-device-messaging)
   * [**Windows Phone Push Notification Service**](#windows-phone-notification-service)
+  * [**Pushy**](#pushy)
 
 #### Feature Highlights
 
@@ -205,6 +206,31 @@ n.uri = 'http://...'
 n.badge = 4
 n.save!
 ```
+
+#### Pushy
+
+[Pushy](https://pushy.me/) is a highly-reliable push notification gateway, based on [MQTT](https://pushy.me/support#what-is-mqtt) protocol for cross platform push notification delivery that includes web, Android, and iOS. One of its advantages is it allows for reliable notification delivery to Android devices in China where Google Cloud Messaging and Firebase Cloud Messaging are blocked and to custom hardware devices that use Android OS but are not using Google Play Services.
+
+Note: current implementation of Pushy only supports Android devices and does not include [subscriptions](https://pushy.me/docs/android/subscribe-topics).
+
+```ruby
+app = Rpush::Pushy::App.new
+app.name = "android_app"
+app.api_key = YOUR_API_KEY
+app.connections = 1
+app.save!
+```
+
+```ruby
+n = Rpush::Pushy::Notification.new
+n.app = Rpush::Pushy::App.find_by_name("android_app")
+n.registration_ids = ["..."]
+n.data = { message: "hi mom!"}
+n.time_to_live = 60 # seconds
+n.save!
+```
+
+For more documentation on [Pushy](https://pushy.me/docs).
 
 ### Running Rpush
 

--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -44,6 +44,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_2_7_0_updates')
     add_rpush_migration('rpush_3_0_0_updates')
     add_rpush_migration('rpush_3_0_1_updates')
+    add_rpush_migration('rpush_3_1_0_add_pushy')
   end
 
   protected

--- a/lib/generators/templates/rpush_3_1_0_add_pushy.rb
+++ b/lib/generators/templates/rpush_3_1_0_add_pushy.rb
@@ -1,0 +1,9 @@
+class Rpush310AddPushy < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
+  def self.up
+    add_column :rpush_notifications, :external_device_id, :string, null: true
+  end
+
+  def self.down
+    remove_column :rpush_notifications, :external_device_id
+  end
+end

--- a/lib/rpush/client/active_model.rb
+++ b/lib/rpush/client/active_model.rb
@@ -25,3 +25,7 @@ require 'rpush/client/active_model/wpns/notification'
 
 require 'rpush/client/active_model/wns/app'
 require 'rpush/client/active_model/wns/notification'
+
+require 'rpush/client/active_model/pushy/app'
+require 'rpush/client/active_model/pushy/notification'
+require 'rpush/client/active_model/pushy/time_to_live_validator'

--- a/lib/rpush/client/active_model/pushy/app.rb
+++ b/lib/rpush/client/active_model/pushy/app.rb
@@ -1,0 +1,20 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Pushy
+        module App
+          def self.included(base)
+            base.instance_eval do
+              alias_attribute :api_key, :auth_key
+              validates :api_key, presence: true
+            end
+          end
+
+          def service_name
+            'pushy'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/pushy/notification.rb
+++ b/lib/rpush/client/active_model/pushy/notification.rb
@@ -1,0 +1,31 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Pushy
+        module Notification
+          def self.included(base)
+            base.instance_eval do
+              alias_attribute :time_to_live, :expiry
+
+              validates :time_to_live, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+              validates :registration_ids, presence: true
+              validates :data, presence: true
+
+              validates_with Rpush::Client::ActiveModel::Pushy::TimeToLiveValidator
+              validates_with Rpush::Client::ActiveModel::PayloadDataSizeValidator, limit: 4096
+              validates_with Rpush::Client::ActiveModel::RegistrationIdsCountValidator, limit: 1000
+            end
+          end
+
+          def as_json(_options = nil)
+            {
+              'data'             => data,
+              'time_to_live'     => time_to_live,
+              'registration_ids' => registration_ids
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/pushy/time_to_live_validator.rb
+++ b/lib/rpush/client/active_model/pushy/time_to_live_validator.rb
@@ -1,0 +1,14 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Pushy
+        class TimeToLiveValidator < ::ActiveModel::Validator
+          def validate(record)
+            return if record.time_to_live.blank? || record.time_to_live <= 1.year.seconds
+            record.errors.add(:time_to_live, 'The maximum value is 1 year')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record.rb
+++ b/lib/rpush/client/active_record.rb
@@ -25,3 +25,6 @@ require 'rpush/client/active_record/wns/app'
 
 require 'rpush/client/active_record/adm/notification'
 require 'rpush/client/active_record/adm/app'
+
+require 'rpush/client/active_record/pushy/notification'
+require 'rpush/client/active_record/pushy/app'

--- a/lib/rpush/client/active_record/pushy/app.rb
+++ b/lib/rpush/client/active_record/pushy/app.rb
@@ -1,0 +1,11 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Pushy
+        class App < Rpush::Client::ActiveRecord::App
+          include Rpush::Client::ActiveModel::Pushy::App
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record/pushy/notification.rb
+++ b/lib/rpush/client/active_record/pushy/notification.rb
@@ -1,0 +1,11 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Pushy
+        class Notification < Rpush::Client::ActiveRecord::Notification
+          include Rpush::Client::ActiveModel::Pushy::Notification
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/redis.rb
+++ b/lib/rpush/client/redis.rb
@@ -38,6 +38,9 @@ require 'rpush/client/redis/wns/notification'
 require 'rpush/client/redis/wns/raw_notification'
 require 'rpush/client/redis/wns/badge_notification'
 
+require 'rpush/client/redis/pushy/app'
+require 'rpush/client/redis/pushy/notification'
+
 Modis.configure do |config|
   config.namespace = :rpush
 end

--- a/lib/rpush/client/redis/app.rb
+++ b/lib/rpush/client/redis/app.rb
@@ -13,6 +13,7 @@ module Rpush
         attribute :auth_key, :string
         attribute :client_id, :string
         attribute :client_secret, :string
+        attribute :api_key, :string
 
         index :name
 

--- a/lib/rpush/client/redis/pushy/app.rb
+++ b/lib/rpush/client/redis/pushy/app.rb
@@ -1,0 +1,16 @@
+module Rpush
+  module Client
+    module Redis
+      module Pushy
+        class App < Rpush::Client::Redis::App
+          include Rpush::Client::ActiveModel::Pushy::App
+
+          def api_key=(value)
+            self.auth_key = value
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/redis/pushy/notification.rb
+++ b/lib/rpush/client/redis/pushy/notification.rb
@@ -1,0 +1,18 @@
+module Rpush
+  module Client
+    module Redis
+      module Pushy
+        class Notification < Rpush::Client::Redis::Notification
+          include Rpush::Client::ActiveModel::Pushy::Notification
+
+          attribute :external_device_id, :string
+
+          def time_to_live=(value)
+            self.expiry = value
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -106,7 +106,7 @@ module Rpush
       client_module = Rpush::Client.const_get(client.to_s.camelize)
       Rpush.send(:include, client_module) unless Rpush.ancestors.include?(client_module)
 
-      [:Apns, :Gcm, :Wpns, :Wns, :Adm].each do |service|
+      [:Apns, :Gcm, :Wpns, :Wns, :Adm, :Pushy].each do |service|
         Rpush.const_set(service, client_module.const_get(service)) unless Rpush.const_defined?(service)
       end
 

--- a/lib/rpush/daemon.rb
+++ b/lib/rpush/daemon.rb
@@ -60,6 +60,9 @@ require 'rpush/daemon/wns'
 require 'rpush/daemon/adm/delivery'
 require 'rpush/daemon/adm'
 
+require 'rpush/daemon/pushy'
+require 'rpush/daemon/pushy/delivery'
+
 module Rpush
   module Daemon
     class << self

--- a/lib/rpush/daemon/pushy.rb
+++ b/lib/rpush/daemon/pushy.rb
@@ -1,0 +1,9 @@
+module Rpush
+  module Daemon
+    module Pushy
+      extend ServiceConfigMethods
+
+      dispatcher :http
+    end
+  end
+end

--- a/lib/rpush/daemon/pushy/delivery.rb
+++ b/lib/rpush/daemon/pushy/delivery.rb
@@ -1,0 +1,90 @@
+module Rpush
+  module Daemon
+    module Pushy
+      class Delivery < Rpush::Daemon::Delivery
+        include MultiJsonHelper
+
+        attr_reader :http, :notification, :batch, :pushy_uri
+
+        def initialize(app, http, notification, batch)
+          @http = http
+          @notification = notification
+          @batch = batch
+          @pushy_uri = URI.parse("https://api.pushy.me/push?api_key=#{app.api_key}")
+        end
+
+        def perform
+          response = send_request
+          process_response(response)
+        rescue SocketError => error
+          mark_retryable(notification, Time.now + 10.seconds, error)
+          raise
+        rescue StandardError => error
+          mark_failed(error)
+          raise
+        ensure
+          batch.notification_processed
+        end
+
+        private
+
+        def send_request
+          post = Net::HTTP::Post.new(pushy_uri)
+          post.content_type = 'application/json'
+          post.body = notification.to_json
+          http.request(pushy_uri, post)
+        end
+
+        def process_response(response)
+          case response.code.to_i
+          when 200
+            process_delivery(response)
+          when 429, 500, 502, 503, 504
+            retry_delivery(response)
+          else
+            fail_delivery(response)
+          end
+        end
+
+        def process_delivery(response)
+          mark_delivered
+          body = multi_json_load(response.body)
+          external_device_id = body['id']
+          notification.external_device_id = external_device_id
+          Rpush::Daemon.store.update_notification(notification)
+          log_info("#{notification.id} received an external id=#{external_device_id}")
+        end
+
+        def retry_delivery(response)
+          time = deliver_after_header(response)
+          if time
+            mark_retryable(notification, time)
+          else
+            mark_retryable_exponential(notification)
+          end
+          log_warn("Pushy responded with a #{response.code} error. #{retry_message}")
+        end
+
+        def deliver_after_header(response)
+          Rpush::Daemon::RetryHeaderParser.parse(response.header['retry-after'])
+        end
+
+        def retry_message
+          deliver_after = notification.deliver_after.strftime('%Y-%m-%d %H:%M:%S')
+          "Notification #{notification.id} will be retried after #{deliver_after} (retry #{notification.retries})."
+        end
+
+        def fail_delivery(response)
+          fail_message = fail_message(response)
+          log_error("#{notification.id} failed: #{fail_message}")
+          fail Rpush::DeliveryError.new(response.code.to_i, notification.id, fail_message)
+        end
+
+        def fail_message(response)
+          body = multi_json_load(response.body)
+          body['error'] || Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i]
+        end
+      end
+    end
+  end
+end

--- a/spec/functional/pushy_spec.rb
+++ b/spec/functional/pushy_spec.rb
@@ -1,0 +1,22 @@
+require 'functional_spec_helper'
+
+describe 'Pushy' do
+  let(:external_device_id) { '5a622ae5813e2875bfdbe496' }
+  let(:response) { instance_double('Net::HTTPResponse', code: 200, body: { id: external_device_id }.to_json) }
+  let(:http) { instance_double('Net::HTTP::Persistent', request: response, shutdown: nil) }
+  let(:app) { Rpush::Pushy::App.create!(name: 'MyApp', api_key: 'my_api_key') }
+
+  let(:notification) do
+    Rpush::Pushy::Notification.create!(app: app, data: { message: 'test' }, registration_ids: ['id'])
+  end
+
+  before do
+    allow(Net::HTTP::Persistent).to receive_messages(new: http)
+  end
+
+  it 'deliveres a notification successfully' do
+    expect { Rpush.push }.to change { notification.reload.delivered }.to(true)
+  end
+
+  it { expect { Rpush.push }.to change { notification.reload.external_device_id }.to(external_device_id) }
+end

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -33,6 +33,7 @@ require 'generators/templates/rpush_2_6_0_updates'
 require 'generators/templates/rpush_2_7_0_updates'
 require 'generators/templates/rpush_3_0_0_updates'
 require 'generators/templates/rpush_3_0_1_updates'
+require 'generators/templates/rpush_3_1_0_add_pushy'
 
 migrations = [
   AddRpush,
@@ -41,7 +42,8 @@ migrations = [
   Rpush260Updates,
   Rpush270Updates,
   Rpush300Updates,
-  Rpush301Updates
+  Rpush301Updates,
+  Rpush310AddPushy
 ]
 
 unless ENV['TRAVIS']

--- a/spec/unit/client/active_record/pushy/app_spec.rb
+++ b/spec/unit/client/active_record/pushy/app_spec.rb
@@ -1,0 +1,17 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::ActiveRecord::Pushy::App do
+  describe 'validates' do
+    subject { described_class.new }
+
+    it 'validates presence of name' do
+      is_expected.not_to be_valid
+      expect(subject.errors[:name]).to eq ["can't be blank"]
+    end
+
+    it 'validates presence of api_key' do
+      is_expected.not_to be_valid
+      expect(subject.errors[:api_key]).to eq ["can't be blank"]
+    end
+  end
+end if active_record?

--- a/spec/unit/client/active_record/pushy/notification_spec.rb
+++ b/spec/unit/client/active_record/pushy/notification_spec.rb
@@ -1,0 +1,65 @@
+require 'unit_spec_helper'
+require 'unit/notification_shared.rb'
+
+describe Rpush::Client::ActiveRecord::Pushy::Notification do
+  let(:notification_class) { described_class }
+  subject(:notification) { notification_class.new }
+
+  it_behaves_like 'an Notification subclass'
+
+  describe 'validates' do
+    let(:app) { Rpush::Client::ActiveRecord::Pushy::App.create!(name: 'MyApp', api_key: 'my_api_key') }
+
+    describe 'data' do
+      subject { described_class.new(app: app, registration_ids: ['id']) }
+      it 'validates presence' do
+        is_expected.not_to be_valid
+        expect(subject.errors[:data]).to eq ["can't be blank"]
+      end
+
+      it "has a 'data' payload limit of 4096 bytes" do
+        subject.data = { message: 'a' * 4096 }
+        is_expected.not_to be_valid
+        expected_errors = ["Notification payload data cannot be larger than 4096 bytes."]
+        expect(subject.errors[:base]).to eq expected_errors
+      end
+    end
+
+    describe 'registration_ids' do
+      subject { described_class.new(app: app, data: { message: 'test' }) }
+      it 'validates presence' do
+        is_expected.not_to be_valid
+        expect(subject.errors[:registration_ids]).to eq ["can't be blank"]
+      end
+
+      it 'limits the number of registration ids to 1000' do
+        subject.registration_ids = ['a'] * (1000 + 1)
+        is_expected.not_to be_valid
+        expected_errors = ["Number of registration_ids cannot be larger than 1000."]
+        expect(subject.errors[:base]).to eq expected_errors
+      end
+    end
+
+    describe 'time_to_live' do
+      subject { described_class.new(app: app, data: { message: 'test' }, registration_ids: ['id']) }
+
+      it 'should be > 0' do
+        subject.time_to_live = -1
+        is_expected.not_to be_valid
+        expect(subject.errors[:time_to_live]).to eq ['must be greater than 0']
+      end
+
+      it 'should be integer' do
+        subject.time_to_live = 1.4
+        is_expected.not_to be_valid
+        expect(subject.errors[:time_to_live]).to eq ['must be an integer']
+      end
+
+      it 'should be <= 1.year.seconds' do
+        subject.time_to_live = 2.years.seconds.to_i
+        is_expected.not_to be_valid
+        expect(subject.errors[:time_to_live]).to eq ['The maximum value is 1 year']
+      end
+    end
+  end
+end if active_record?

--- a/spec/unit/daemon/pushy/delivery_spec.rb
+++ b/spec/unit/daemon/pushy/delivery_spec.rb
@@ -1,0 +1,159 @@
+require 'unit_spec_helper'
+
+describe Rpush::Daemon::Pushy::Delivery do
+  let(:app) { Rpush::Pushy::App.create!(name: 'MyApp', api_key: 'my_api_key') }
+  let(:token) { 'device token' }
+  let(:data) { { message: 'some message' } }
+  let(:notification) { Rpush::Pushy::Notification.create!(app: app, registration_ids: [token], data: data) }
+  let(:batch) { instance_double('Rpush::Daemon::Batch', notification_processed: nil) }
+  let(:response) { instance_double('Net::HTTPResponse', code: response_code, header: response_header) }
+  let(:response_code) { 200 }
+  let(:response_header) { {} }
+  let(:http) { instance_double('Net::HTTP::Persistent', request: response) }
+  let(:logger) { instance_double('Rpush::Logger', error: nil, info: nil, warn: nil, internal_logger: nil) }
+  let(:now) { Time.parse('2018-01-19 00:00:00 UTC') }
+
+  before do
+    allow(Rpush).to receive_messages(logger: logger)
+    allow(Time).to receive_messages(now: now)
+  end
+
+  subject(:delivery) { described_class.new(app, http, notification, batch) }
+
+  describe '#pushy_uri' do
+    it { expect(subject.pushy_uri).to eq URI.parse('https://api.pushy.me/push?api_key=my_api_key') }
+  end
+
+  describe '#perform' do
+    shared_examples 'process notification' do
+      it 'invoke batch.notification_processed' do
+        subject.perform rescue nil
+        expect(batch).to have_received(:notification_processed)
+      end
+    end
+
+    context 'when response code is 200' do
+      let(:external_device_id) { '5a60ca7f6ad08477b5070dd3' }
+
+      before do
+        allow(batch).to receive(:mark_delivered)
+        response_body = {
+          success: true,
+          id: external_device_id
+        }
+        allow(response).to receive(:body) { response_body.to_json }
+        Rpush::Daemon.store = Rpush::Daemon::Store.const_get(Rpush.config.client.to_s.camelcase).new
+      end
+
+      it 'marks the notification as delivered' do
+        delivery.perform
+        expect(batch).to have_received(:mark_delivered).with(notification)
+      end
+
+      it { expect { delivery.perform }.to change { notification.external_device_id }.to(external_device_id) }
+
+      it 'logs than notification received an external id' do
+        delivery.perform
+        expected = "#{notification.id} received an external id=5a60ca7f6ad08477b5070dd3"
+        expect(logger).to have_received(:info).with(expected)
+      end
+
+      it_behaves_like 'process notification'
+    end
+
+    shared_examples 'retry delivery' do |response_code:|
+      let(:response_code) { response_code }
+
+      shared_examples 'logs' do |deliver_after:|
+        let(:expected_log_message) do
+          "Pushy responded with a #{response_code} error. Notification #{notification.id} " \
+          "will be retried after #{deliver_after} (retry 1)."
+        end
+
+        it 'logs that the notification will be retried' do
+          delivery.perform
+          expect(logger).to have_received(:warn).with(expected_log_message)
+        end
+      end
+
+      context 'when Retry-After header is present' do
+        let(:response_header) { { 'retry-after' => 10 } }
+
+        before do
+          allow(delivery).to receive(:mark_retryable) do
+            notification.deliver_after = now + 10.seconds
+            notification.retries += 1
+          end
+        end
+
+        it 'retry the notification' do
+          delivery.perform
+          expect(delivery).to have_received(:mark_retryable).with(notification, now + 10.seconds)
+        end
+
+        it_behaves_like 'logs', deliver_after: '2018-01-19 00:00:10'
+        it_behaves_like 'process notification'
+      end
+
+      context 'when Retry-After header is not present' do
+        before do
+          allow(delivery).to receive(:mark_retryable_exponential) do
+            notification.deliver_after = now + 2.seconds
+            notification.retries = 1
+          end
+        end
+
+        it 'retry the notification' do
+          delivery.perform
+          expect(delivery).to have_received(:mark_retryable_exponential).with(notification)
+        end
+
+        it_behaves_like 'logs', deliver_after: '2018-01-19 00:00:02'
+        it_behaves_like 'process notification'
+      end
+    end
+
+    it_behaves_like 'retry delivery', response_code: 429
+    it_behaves_like 'retry delivery', response_code: 500
+    it_behaves_like 'retry delivery', response_code: 502
+    it_behaves_like 'retry delivery', response_code: 503
+    it_behaves_like 'retry delivery', response_code: 504
+
+    context 'when delivery failed' do
+      let(:response_code) { 400 }
+      let(:fail_message) { 'No devices matched the specified condition.' }
+      before do
+        allow(response).to receive(:body) { { error: fail_message }.to_json }
+        allow(batch).to receive(:mark_failed)
+      end
+
+      it 'logs that the notifications failed' do
+        expect { delivery.perform }.to raise_error(Rpush::DeliveryError)
+        expect(logger).to have_received(:error).with("#{notification.id} failed: #{fail_message}")
+      end
+
+      it 'marks the notification as failed' do
+        expect { delivery.perform }.to raise_error(Rpush::DeliveryError)
+        expected_message = "Unable to deliver notification #{notification.id}, " \
+                           "received error 400 (#{fail_message})"
+        expect(batch).to have_received(:mark_failed).with(notification, 400, expected_message)
+      end
+
+      it_behaves_like 'process notification'
+    end
+
+    context 'when SocketError raised' do
+      before do
+        allow(http).to receive(:request) { raise SocketError }
+        allow(delivery).to receive(:mark_retryable)
+      end
+
+      it 'retry delivery after 10 seconds' do
+        expect { delivery.perform }.to raise_error(SocketError)
+        expect(delivery).to have_received(:mark_retryable).with(notification, now + 10.seconds, SocketError)
+      end
+
+      it_behaves_like 'process notification'
+    end
+  end
+end


### PR DESCRIPTION
[Pushy](https://pushy.me/) is a highly-reliable push notification gateway, based on [MQTT](https://pushy.me/support#what-is-mqtt) protocol. It allows to deliver notifications reliably to Android devices in China (Google Cloud Messaging and Firebase Cloud Messaging are blocked in China).