### PR TITLE
Add minimal error handler for Net::Http2 client reqeust

### DIFF
--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -57,6 +57,10 @@ module Rpush
 
           http_request.on(:close) { handle_response(notification, response) }
 
+          http_request.on(:error) do |error|
+            log_error("Error sending notification #{notification.id}: #{error}")
+          end
+
           @client.call_async(http_request)
         end
 


### PR DESCRIPTION
This is to prevent things like Errno::ECONNRESET from terminating the
dispatcher in daemon mode, which leaves the notifications stuck
forever in the processing state.

Perhaps more can be done here, whether to mark the notification for
retry or failure is perhaps something for the user to configure.

See https://github.com/ostinelli/net-http2/issues/23#issuecomment-361616710