### PR TITLE
improving documentation to indicate that title or body should be present in FCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ n.registration_ids = ["..."]
 n.data = { message: "hi mom!" }
 n.priority = 'high'        # Optional, can be either 'normal' or 'high'
 n.content_available = true # Optional
-# Optional notification payload. See the reference below for more keys you can use!
+# You must define at least `body` or `title` fiels to your notification appear. See the reference below for more keys you can use!
 n.notification = { body: 'great match!',
                    title: 'Portugal vs. Denmark',
                    icon: 'myicon'


### PR DESCRIPTION
Hello! I recently started to use Rpush in my project. In the documentation for GCM/FCM, it's says

```ruby
# Optional notification payload. See the reference below for more keys you can use!
n.notification = { 
  body: 'great match!',
  title: 'Portugal vs. Denmark',
  icon: 'myicon'
}
```

Initialy, as I was trying to make a simple sample to my notifications work, I removed this field thinking all keys are optional. 
Then, I used `$ rpush push` to send my recently created notifications but none arrived. I checked using `rails c` and all `notification.delivered` are true. The device that I'm using to receive the notifications is iOS.

After a few time debugging, I tried to add 

```
n.notification = { 
  body: 'example',
}
```

 in my logic and suddenly started to work. This led me to believe that `body` or `title` should be present to a notification appear to the user in his device. At least in iOS.

There're a [issue](https://github.com/rpush/rpush/issues/113) that demonstrates the same behavior.

Then, I created this pull request in hope to future developers don't make the same mistake. I'm open to talk about the problem that I describe too!

Hope it helps.
