### PR TITLE
Require 'rpush'

### DIFF
--- a/lib/generators/templates/rpush.rb
+++ b/lib/generators/templates/rpush.rb
@@ -1,3 +1,4 @@
+require 'rpush'
 Rpush.configure do |config|
 
   # Supported clients are :active_record and :redis


### PR DESCRIPTION
Require 'rpush' to resolve uninitialized constant error.