### PR TITLE
rpush_notifications active_record performance improvements

### DIFF
--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -44,6 +44,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_2_7_0_updates')
     add_rpush_migration('rpush_3_0_0_updates')
     add_rpush_migration('rpush_3_0_1_updates')
+    add_rpush_migration('rpush_3_0_3_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_3_0_3_updates.rb
+++ b/lib/generators/templates/rpush_3_0_3_updates.rb
@@ -1,0 +1,15 @@
+class Rpush303Updates < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
+  def self.up
+    change_table :rpush_notifications do |t|
+      t.remove_index name: 'index_rpush_notifications_multi'
+      t.index [:delivered, :failed, :processing, :deliver_after, :created_at], name: 'index_rpush_notifications_multi', where: 'NOT delivered AND NOT failed'
+    end
+  end
+
+  def self.down
+    change_table :rpush_notifications do |t|
+      t.remove_index name: 'index_rpush_notifications_multi'
+      t.index [:delivered, :failed], name: 'index_rpush_notifications_multi', where: 'NOT delivered AND NOT failed'
+    end
+  end
+end

--- a/lib/rpush/daemon/store/active_record.rb
+++ b/lib/rpush/daemon/store/active_record.rb
@@ -11,7 +11,6 @@ module Rpush
         DEFAULT_MARK_OPTIONS = { persist: true }
 
         def initialize
-          @using_oracle = adapter_name =~ /oracle/
           reopen_log unless Rpush.config.embedded
         end
 
@@ -29,13 +28,21 @@ module Rpush
 
         def deliverable_notifications(limit)
           with_database_reconnect_and_retry do
-            Rpush::Client::ActiveRecord::Notification.transaction do
+            notifications = Rpush::Client::ActiveRecord::Notification.transaction do
               relation = ready_for_delivery
               relation = relation.limit(limit)
-              notifications = claim(relation)
-              mark_processing(notifications)
-              notifications
+              ids = relation.lock(true).pluck(:id)
+              unless ids.empty?
+                relation = Rpush::Client::ActiveRecord::Notification.where(id: ids)
+                # mark processing
+                relation.update_all(processing: true, updated_at: Time.now)
+                relation
+              else
+                []
+              end
             end
+
+            notifications.to_a
           end
         end
 
@@ -190,23 +197,7 @@ module Rpush
 
         def ready_for_delivery
           relation = Rpush::Client::ActiveRecord::Notification.where('processing = ? AND delivered = ? AND failed = ? AND (deliver_after IS NULL OR deliver_after < ?)', false, false, false, Time.now)
-          @using_oracle ? relation : relation.order('created_at ASC')
-        end
-
-        def mark_processing(notifications)
-          return if notifications.empty?
-
-          ids = []
-          notifications.each do |n|
-            n.processing = true
-            ids << n.id
-          end
-          Rpush::Client::ActiveRecord::Notification.where(id: ids).update_all(['processing = ?', true])
-        end
-
-        def claim(relation)
-          notifications = relation.lock(true).to_a
-          @using_oracle ? notifications.sort_by(&:created_at) : notifications
+          relation.order('deliver_after ASC, created_at ASC')
         end
 
         def adapter_name

--- a/lib/rpush/daemon/store/active_record.rb
+++ b/lib/rpush/daemon/store/active_record.rb
@@ -31,7 +31,7 @@ module Rpush
             notifications = Rpush::Client::ActiveRecord::Notification.transaction do
               relation = ready_for_delivery
               relation = relation.limit(limit)
-              ids = relation.lock(true).pluck(:id)
+              ids = relation.lock(true).ids
               unless ids.empty?
                 relation = Rpush::Client::ActiveRecord::Notification.where(id: ids)
                 # mark processing

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -33,6 +33,7 @@ require 'generators/templates/rpush_2_6_0_updates'
 require 'generators/templates/rpush_2_7_0_updates'
 require 'generators/templates/rpush_3_0_0_updates'
 require 'generators/templates/rpush_3_0_1_updates'
+require 'generators/templates/rpush_3_0_3_updates'
 
 migrations = [
   AddRpush,
@@ -41,7 +42,8 @@ migrations = [
   Rpush260Updates,
   Rpush270Updates,
   Rpush300Updates,
-  Rpush301Updates
+  Rpush301Updates,
+  Rpush303Updates
 ]
 
 unless ENV['TRAVIS']

--- a/spec/unit/daemon/store/active_record_spec.rb
+++ b/spec/unit/daemon/store/active_record_spec.rb
@@ -63,7 +63,7 @@ describe Rpush::Daemon::Store::ActiveRecord do
       Rpush.config.batch_size = 5000
       relation = double.as_null_object
       expect(relation).to receive(:limit).with(5000)
-      allow(relation).to receive_messages(to_a: [])
+      allow(relation).to receive_messages(pluck: [])
       allow(store).to receive_messages(ready_for_delivery: relation)
       store.deliverable_notifications(Rpush.config.batch_size)
     end


### PR DESCRIPTION
1. Change the index on rpush_notifications to minimize number of locked records and pre-sort the records
2. Minimize the locking duration by moving the row dump code outside of the transaction

fixes #200