### PR TITLE
Fix interruptible_sleep memory leak (#439)

### DIFF
--- a/lib/rpush/daemon/interruptible_sleep.rb
+++ b/lib/rpush/daemon/interruptible_sleep.rb
@@ -7,7 +7,8 @@ module Rpush
 
         begin
           @thread.join
-        rescue StandardError
+        rescue StandardError # rubocop:disable Lint/HandleExceptions
+        ensure
           @thread = nil
         end
       end

--- a/lib/rpush/version.rb
+++ b/lib/rpush/version.rb
@@ -2,7 +2,7 @@ module Rpush
   module VERSION
     MAJOR = 3
     MINOR = 2
-    TINY = 0
+    TINY = 1
     PRE = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".").freeze


### PR DESCRIPTION
I ran a memory benchmark using [michaelherold/benchmark-memory](https://github.com/michaelherold/benchmark-memory) and the it seems like ruby does retain the dead threads if the instance var is not explicitly set to `nil`

```ruby
require 'benchmark/memory'

class InterruptibleSleep
  def sleep(duration)
    @thread = Thread.new { Kernel.sleep(duration) }
    Thread.pass

    begin
      @thread.join
    rescue StandardError
      @thread = nil
    end
  end

  def stop
    @thread.kill if @thread
  rescue StandardError # rubocop:disable Lint/HandleExceptions
  ensure
    @thread = nil
  end
end

class InterruptibleSleep2 < InterruptibleSleep
  def sleep(duration)
    @thread = Thread.new { Kernel.sleep(duration) }
    Thread.pass

    begin
      @thread.join
    rescue StandardError
    ensure
      @thread = nil
    end
  end
end

class InterruptibleSleep3 < InterruptibleSleep
  def sleep(duration)
    @thread = Thread.new { Kernel.sleep(duration); nil }
    Thread.pass

    begin
      @thread.join
    rescue StandardError
      @thread = nil
    end
  end
end

SLEEP = 0.001 # seconds

is = InterruptibleSleep.new
is2 = InterruptibleSleep2.new
is3 = InterruptibleSleep3.new

Benchmark.memory do |x|
  x.report('IS Originial') { is.sleep(SLEEP) }
  x.report('IS 2') { is2.sleep(SLEEP) }
  x.report('IS 3') { is3.sleep(SLEEP) }

  x.compare!
end
```

Pay attention to `IS 2` which is the code that is on this PR, and it doesn't retain anything in memory.
```
Calculating -------------------------------------
        IS Originial     1.050M memsize (     1.050M retained)
                         4.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)
                IS 2     1.050M memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
                IS 3     1.050M memsize (     1.050M retained)
                         4.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
        IS Originial:    1049712 allocated
                IS 2:    1049712 allocated - same
                IS 3:    1049712 allocated - same
```