### PR TITLE
Update jwt to 2.1.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -38,10 +38,10 @@ appraise "rails-5.1" do
 end
 
 appraise "rails-5.2" do
-  gem "activesupport", ">= 5.2.0.beta2"
+  gem "activesupport", ">= 5.2.0"
 
   group :development do
-    gem "rails", ">= 5.2.0.beta2"
+    gem "rails", ">= 5.2.0"
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    rpush (3.2.0)
+    rpush (3.2.2)
       activesupport
       ansi
-      jwt (~> 1.5.6)
+      jwt (~> 2.1.0)
       multi_json (~> 1.0)
       net-http-persistent
       net-http2 (~> 0.14)
@@ -58,7 +58,7 @@ GEM
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    jwt (1.5.6)
+    jwt (2.1.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -77,9 +77,9 @@ GEM
     mysql2 (0.5.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    net-http2 (0.17.0)
+    net-http2 (0.18.0)
       http-2 (= 0.9.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)

--- a/lib/rpush/daemon/apnsp8/token.rb
+++ b/lib/rpush/daemon/apnsp8/token.rb
@@ -3,7 +3,6 @@ module Rpush
     module Apnsp8
       TOKEN_TTL = 30 * 60
       class Token
-
         def initialize(app)
           @app = app
         end
@@ -15,13 +14,24 @@ module Rpush
             new_token
           end
         end
-        
+
         private
 
         def new_token
           @cached_token_at = Time.now
           ec_key = OpenSSL::PKey::EC.new(@app.apn_key)
-          @cached_token = JWT.encode({iss: @app.team_id, iat: Time.now.to_i}, ec_key, 'ES256', {alg: 'ES256', kid: @app.apn_key_id})
+          @cached_token = JWT.encode(
+            {
+              iss: @app.team_id,
+              iat: Time.now.to_i
+            },
+            ec_key,
+            'ES256',
+            {
+              alg: 'ES256',
+              kid: @app.apn_key_id
+            }
+          )
         end
 
         def expired_token?

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_json', '~> 1.0'
   s.add_runtime_dependency 'net-http-persistent'
   s.add_runtime_dependency 'net-http2', '~> 0.14'
-  s.add_runtime_dependency 'jwt', '~> 1.5.6'
+  s.add_runtime_dependency 'jwt', '~> 2.1.0'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'


### PR DESCRIPTION
Fixes #435

I've also removed the references to `rails 5.2.0.beta2`, since a final version has been out for a while.

On `lib/rpush/daemon/apnsp8/token.rb` I just did some styling adjustments suggested by Rubocop (haven't really changed anything, but was consulting the class to confirm if anything had to be changed).

@aried3r please take a look since you were involved on the APNS P8 integration. Wonder if there shouldn't be some tests for this...