### PR TITLE
 Apns::Notification should be able to store multiple registration_ids

### DIFF
--- a/lib/rpush/client/active_model/apns/notification.rb
+++ b/lib/rpush/client/active_model/apns/notification.rb
@@ -74,18 +74,19 @@ module Rpush
             json
           end
 
-          def to_binary(options = {})
-            [*device_token, *registration_ids].each_with_index.map do |device_token, index|
-              frame_payload = payload
-              frame_id = options[:for_validation] ? 0 : send(options.fetch(:id_attribute, :id))
-              frame = ""
-              frame << [1, 32, device_token].pack("cnH*")
-              frame << [2, frame_payload.bytesize, frame_payload].pack("cna*")
-              frame << [3, 4, frame_id ^ index].pack("cnN")
-              frame << [4, 4, expiry ? Time.now.to_i + expiry.to_i : 0].pack("cnN")
-              frame << [5, 1, priority_for_frame].pack("cnc")
-              [2, frame.bytesize].pack("cN") + frame
-            end.join
+          def device_tokens
+            [*device_token, *registration_ids]
+          end
+
+          def to_binary(frame_id: public_send(:id), device_token: self.device_token)
+            frame_payload = payload
+            frame = ""
+            frame << [1, 32, device_token].pack("cnH*")
+            frame << [2, frame_payload.bytesize, frame_payload].pack("cna*")
+            frame << [3, 4, frame_id].pack("cnN")
+            frame << [4, 4, expiry ? Time.now.to_i + expiry.to_i : 0].pack("cnN")
+            frame << [5, 1, priority_for_frame].pack("cnc")
+            [2, frame.bytesize].pack("cN") + frame
           end
 
           private

--- a/lib/rpush/daemon/apns/delivery.rb
+++ b/lib/rpush/daemon/apns/delivery.rb
@@ -26,8 +26,10 @@ module Rpush
 
         def batch_to_binary
           payload = ""
-          @batch.each_notification do |notification|
-            payload << notification.to_binary
+          @batch
+            .each_notification.lazy.flat_map { |notification| notification.device_tokens.zip([notification].cycle) }
+            .each_with_index do |(device_token, notification), frame_id|
+            payload << notification.to_binary(frame_id: frame_id, device_token: device_token)
           end
           payload
         end

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -286,7 +286,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, "bug #35" do
       n.app = Rpush::Client::ActiveRecord::Apns::App.create!(name: 'my_app', environment: 'development', certificate: TEST_CERT)
     end
 
-    expect(notification.to_binary(for_validation: true).bytesize).to be > 256
+    expect(notification.to_binary(frame_id: 0).bytesize).to be > 256
     expect(notification.payload.bytesize).to be < 256
     expect(notification).to be_valid
   end

--- a/spec/unit/daemon/apns/delivery_spec.rb
+++ b/spec/unit/daemon/apns/delivery_spec.rb
@@ -17,8 +17,8 @@ describe Rpush::Daemon::Apns::Delivery do
   end
 
   it 'writes the binary batch' do
-    allow(notification1).to receive_messages(to_binary: 'binary1')
-    allow(notification2).to receive_messages(to_binary: 'binary2')
+    allow(notification1).to receive_messages(to_binary: 'binary1', device_tokens: ['abc123'])
+    allow(notification2).to receive_messages(to_binary: 'binary2', device_tokens: ['abc123'])
     expect(connection).to receive(:write).with('binary1binary2')
     delivery.perform
   end


### PR DESCRIPTION
Hello. Putting multiple `device_token`s in a single notification could ease things when sending large push campaigns.
