### PR TITLE
Retry all GCM 5xx errors

### DIFF
--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -133,7 +133,7 @@ module Rpush
           log_warn("GCM responded with an Service Unavailable Error. " + retry_message)
         end
 
-        def other_5xx_error
+        def other_5xx_error(response)
           retry_delivery(@notification, response)
           log_warn("GCM responded with a 5xx Error. " + retry_message)
         end

--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -45,6 +45,8 @@ module Rpush
             bad_gateway(response)
           when 503
             service_unavailable(response)
+          when 500..599
+            other_5xx_error(response)
           else
             fail Rpush::DeliveryError.new(response.code.to_i, @notification.id, Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i])
           end
@@ -129,6 +131,11 @@ module Rpush
         def service_unavailable(response)
           retry_delivery(@notification, response)
           log_warn("GCM responded with an Service Unavailable Error. " + retry_message)
+        end
+
+        def other_5xx_error
+          retry_delivery(@notification, response)
+          log_warn("GCM responded with a 5xx Error. " + retry_message)
         end
 
         def deliver_after_header(response)

--- a/spec/unit/daemon/gcm/delivery_spec.rb
+++ b/spec/unit/daemon/gcm/delivery_spec.rb
@@ -329,6 +329,34 @@ describe Rpush::Daemon::Gcm::Delivery do
     end
   end
 
+  describe 'a 5xx response' do
+    before { allow(response).to receive_messages(code: 555) }
+
+    it 'logs a warning that the notification will be retried.' do
+      notification.retries = 1
+      notification.deliver_after = now + 2
+      expect(logger).to receive(:warn).with("[MyApp] GCM responded with a 5xx Error. Notification #{notification.id} will be retried after 2012-10-14 00:00:02 (retry 1).")
+      perform
+    end
+
+    it 'respects an integer Retry-After header' do
+      allow(response).to receive_messages(header: { 'retry-after' => 10 })
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 10.seconds)
+      perform
+    end
+
+    it 'respects a HTTP-date Retry-After header' do
+      allow(response).to receive_messages(header: { 'retry-after' => 'Wed, 03 Oct 2012 20:55:11 GMT' })
+      expect(delivery).to receive(:mark_retryable).with(notification, Time.parse('Wed, 03 Oct 2012 20:55:11 GMT'))
+      perform
+    end
+
+    it 'defaults to exponential back-off if the Retry-After header is not present' do
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 2**1)
+      perform
+    end
+  end
+
   describe 'a 401 response' do
     before { allow(response).to receive_messages(code: 401) }
 

--- a/spec/unit/daemon/gcm/delivery_spec.rb
+++ b/spec/unit/daemon/gcm/delivery_spec.rb
@@ -282,6 +282,34 @@ describe Rpush::Daemon::Gcm::Delivery do
     end
   end
 
+  describe 'a 502 response' do
+    before { allow(response).to receive_messages(code: 502) }
+
+    it 'logs a warning that the notification will be retried.' do
+      notification.retries = 1
+      notification.deliver_after = now + 2
+      expect(logger).to receive(:warn).with("[MyApp] GCM responded with a Bad Gateway Error. Notification #{notification.id} will be retried after 2012-10-14 00:00:02 (retry 1).")
+      perform
+    end
+
+    it 'respects an integer Retry-After header' do
+      allow(response).to receive_messages(header: { 'retry-after' => 10 })
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 10.seconds)
+      perform
+    end
+
+    it 'respects a HTTP-date Retry-After header' do
+      allow(response).to receive_messages(header: { 'retry-after' => 'Wed, 03 Oct 2012 20:55:11 GMT' })
+      expect(delivery).to receive(:mark_retryable).with(notification, Time.parse('Wed, 03 Oct 2012 20:55:11 GMT'))
+      perform
+    end
+
+    it 'defaults to exponential back-off if the Retry-After header is not present' do
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 2**1)
+      perform
+    end
+  end
+
   describe 'a 500 response' do
     before do
       notification.update_attribute(:retries, 2)


### PR DESCRIPTION
According to the [GCM docs](https://developers.google.com/cloud-messaging/http-server-ref#error-codes), for errors in the 500-599 range, the sender "must retry later". Currently, rpush only retries these notifications if the error is specifically 500 or 503.

In production, we have seen this somewhat commonly with 502 Bad Gateway errors. This PR adds specific retry handling for 502 errors, as well as general purpose retry handling for other 5xx GCM errors.