### PR TITLE
Remove unused class ConfigurationWithoutDefaults

### DIFF
--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -21,7 +21,6 @@ module Rpush
   CONFIG_ATTRS = CURRENT_ATTRS + DEPRECATED_ATTRS
 
   class ConfigurationError < StandardError; end
-  class ConfigurationWithoutDefaults < Struct.new(*CONFIG_ATTRS); end # rubocop:disable Style/StructInheritance
 
   class ApnsFeedbackReceiverConfiguration < Struct.new(:frequency, :enabled) # rubocop:disable Style/StructInheritance
     def initialize


### PR DESCRIPTION
It was used before this commit: 0e0781ec4a1274b6f9aad3abb56717fb310ce1b4