### PR TITLE
remove validation of 64-characters length from device_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ app.save!
 ```ruby
 n = Rpush::Apns::Notification.new
 n.app = Rpush::Apns::App.find_by_name("ios_app")
-n.device_token = "..." # 64-character hex string
+n.device_token = "..." # hex string
 n.alert = "hi mom!"
 n.data = { foo: :bar }
 n.save!
@@ -97,7 +97,7 @@ app.save!
 ```ruby
 n = Rpush::Apns::Notification.new
 n.app = Rpush::Apnsp8::App.find_by_name("ios_app")
-n.device_token = "..." # 64-character hex string
+n.device_token = "..." # hex string
 n.alert = "hi mom!"
 n.data = { foo: :bar }
 n.save!

--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -49,6 +49,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_3_2_0_add_apns_p8')
     add_rpush_migration('rpush_3_2_4_updates')
     add_rpush_migration('rpush_3_3_0_updates')
+    add_rpush_migration('rpush_3_3_1_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_3_3_1_updates.rb
+++ b/lib/generators/templates/rpush_3_3_1_updates.rb
@@ -1,0 +1,11 @@
+class Rpush331Updates < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
+  def self.up
+    change_column :rpush_notifications, :device_token, :string, null: true
+    change_column :rpush_feedback, :device_token, :string, null: true
+  end
+
+  def self.down
+    change_column :rpush_notifications, :device_token, :string, { null: true, limit: 64 }
+    change_column :rpush_feedback, :device_token, :string, { null: true, limit: 64 }
+  end
+end

--- a/lib/rpush/client/active_model/apns/device_token_format_validator.rb
+++ b/lib/rpush/client/active_model/apns/device_token_format_validator.rb
@@ -4,7 +4,7 @@ module Rpush
       module Apns
         class DeviceTokenFormatValidator < ::ActiveModel::Validator
           def validate(record)
-            return if record.device_token =~ /^[a-z0-9]{64}$/i
+            return if record.device_token =~ /^[a-z0-9]\w+$/i
             record.errors[:device_token] << "is invalid"
           end
         end

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -11,7 +11,7 @@ describe 'APNs http2 adapter' do
     )
   }
   let(:app) { create_app }
-  let(:fake_device_token) { 'a' * 64 }
+  let(:fake_device_token) { 'a' * 108 }
   let(:fake_http2_request) { double }
   let(:fake_http_resp_headers) {
     {

--- a/spec/functional/apns_spec.rb
+++ b/spec/functional/apns_spec.rb
@@ -27,7 +27,7 @@ describe 'APNs' do
     notification = Rpush::Apns::Notification.new
     notification.app = app
     notification.alert = 'test'
-    notification.device_token = 'a' * 64
+    notification.device_token = 'a' * 108
     notification.save!
     notification
   end

--- a/spec/functional/embed_spec.rb
+++ b/spec/functional/embed_spec.rb
@@ -16,7 +16,7 @@ describe 'embedding' do
 
     notification.app = app
     notification.alert = 'test'
-    notification.device_token = 'a' * 64
+    notification.device_token = 'a' * 108
     notification.save!
 
     stub_tcp_connection

--- a/spec/functional/new_app_spec.rb
+++ b/spec/functional/new_app_spec.rb
@@ -24,7 +24,7 @@ describe 'New app loading' do
     notification = Rpush::Apns::Notification.new
     notification.app = app
     notification.alert = 'test'
-    notification.device_token = 'a' * 64
+    notification.device_token = 'a' * 108
     notification.save!
     notification
   end

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -38,6 +38,7 @@ require 'generators/templates/rpush_3_1_1_updates'
 require 'generators/templates/rpush_3_2_0_add_apns_p8'
 require 'generators/templates/rpush_3_2_4_updates'
 require 'generators/templates/rpush_3_3_0_updates'
+require 'generators/templates/rpush_3_3_1_updates'
 
 migrations = [
   AddRpush,
@@ -51,7 +52,8 @@ migrations = [
   Rpush311Updates,
   Rpush320AddApnsP8,
   Rpush324Updates,
-  Rpush330Updates
+  Rpush330Updates,
+  Rpush331Updates
 ]
 
 unless ENV['TRAVIS']

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -17,7 +17,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification do
   end
 
   it "should validate the length of the binary conversion of the notification" do
-    notification.device_token = "a" * 64
+    notification.device_token = "a" * 108
     notification.alert = "way too long!" * 200
     expect(notification.valid?).to be_falsey
     expect(notification.errors[:base].include?("APN notification cannot be larger than 2048 bytes. Try condensing your alert and device attributes.")).to be_truthy
@@ -25,7 +25,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification do
 
   it "should store long alerts" do
     notification.app = app
-    notification.device_token = "a" * 64
+    notification.device_token = "a" * 108
     notification.alert = "*" * 300
     expect(notification.valid?).to be_truthy
 
@@ -110,7 +110,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'MDM' do
   let(:notification) { Rpush::Client::ActiveRecord::Apns::Notification.new }
 
   before do
-    notification.device_token = "a" * 64
+    notification.device_token = "a" * 108
     notification.id = 1234
   end
 
@@ -225,7 +225,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'to_binary' do
   let(:notification) { Rpush::Client::ActiveRecord::Apns::Notification.new }
 
   before do
-    notification.device_token = "a" * 64
+    notification.device_token = "a" * 108
     notification.id = 1234
   end
 
@@ -259,7 +259,7 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, 'to_binary' do
     notification.app = Rpush::Client::ActiveRecord::Apns::App.new(name: 'my_app', environment: 'development', certificate: TEST_CERT)
     now = Time.now
     allow(Time).to receive_messages(now: now)
-    expect(notification.to_binary).to eq "\x02\x00\x00\x00\x99\x01\x00 \xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\x02\x00a{\"aps\":{\"alert\":\"Don't panic Mr Mainwaring, don't panic!\",\"badge\":3,\"sound\":\"1.aiff\"},\"hi\":\"mom\"}\x03\x00\x04\x00\x00\x04\xD2\x04\x00\x04#{[now.to_i + 86_400].pack('N')}\x05\x00\x01\n"
+    expect(notification.to_binary).to eq "\x02\x00\x00\x00\xAF\x01\x00 \xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\x02\x00a{\"aps\":{\"alert\":\"Don't panic Mr Mainwaring, don't panic!\",\"badge\":3,\"sound\":\"1.aiff\"},\"hi\":\"mom\"}\x03\x00\x04\x00\x00\x04\xD2\x04\x00\x04#{[now.to_i + 86_400].pack('N')}\x05\x00\x01\n"
   end
 end if active_record?
 
@@ -281,7 +281,7 @@ end if active_record?
 describe Rpush::Client::ActiveRecord::Apns::Notification, "bug #35" do
   it "should limit payload size to 256 bytes but not the entire packet" do
     notification = Rpush::Client::ActiveRecord::Apns::Notification.new do |n|
-      n.device_token = "a" * 64
+      n.device_token = "a" * 108
       n.alert = "a" * 210
       n.app = Rpush::Client::ActiveRecord::Apns::App.create!(name: 'my_app', environment: 'development', certificate: TEST_CERT)
     end

--- a/spec/unit/daemon/feeder_spec.rb
+++ b/spec/unit/daemon/feeder_spec.rb
@@ -2,7 +2,7 @@ require "unit_spec_helper"
 
 describe Rpush::Daemon::Feeder do
   let!(:app) { Rpush::Apns::App.create!(name: 'my_app', environment: 'development', certificate: TEST_CERT) }
-  let(:notification) { Rpush::Apns::Notification.create!(device_token: "a" * 64, app: app) }
+  let(:notification) { Rpush::Apns::Notification.create!(device_token: "a" * 108, app: app) }
   let(:logger) { double }
   let(:interruptible_sleeper) { double(sleep: nil, stop: nil) }
   let(:store) { double(Rpush::Daemon::Store::ActiveRecord, deliverable_notifications: [notification], release_connection: nil) }


### PR DESCRIPTION
This PR migrates the device_token from string(64) to just string - 255 characters. My first thought was to migrate the field to a text field, but then I saw that we have indexes on device_token and a very big field could be a problem. And with text field I actually couldn't run the migration. :(

Fixes #462