### PR TITLE
APNS p8 improvements

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -14,8 +14,6 @@ module Rpush
           @batch = batch
           @first_push = true
           @token_provider = token_provider
-
-          @client.on(:error) { |err| mark_batch_retryable(Time.now + 10.seconds, err) }
         end
 
         def perform

--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -14,11 +14,11 @@ module Rpush
           @batch = batch
           @first_push = true
           @token_provider = token_provider
+
+          @client.on(:error) { |err| mark_batch_retryable(Time.now + 10.seconds, err) }
         end
 
         def perform
-          @client.on(:error) { |err| mark_batch_retryable(Time.now + 10.seconds, err) }
-
           @batch.each_notification do |notification|
             prepare_async_post(notification)
           end

--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -43,7 +43,6 @@ module Rpush
           response = {}
 
           request = build_request(notification)
-          log_warn(request)
           http_request = @client.prepare_request(:post, request[:path],
             body:    request[:body],
             headers: request[:headers]

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -16,11 +16,11 @@ module Rpush
 
           url = URLS[app.environment.to_sym]
           @client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_TIMEOUT)
+          @client.on(:error) {|error| reflect(:error, error)}
           @token_provider = Rpush::Daemon::Apnsp8::Token.new(@app)
         end
 
         def dispatch(payload)
-
           @delivery_class.new(@app, @client, @token_provider, payload.batch).perform
         end
 

--- a/lib/rpush/logger.rb
+++ b/lib/rpush/logger.rb
@@ -65,7 +65,7 @@ module Rpush
 
     def log(where, msg, inline = false, prefix = nil, io = STDOUT)
       if msg.is_a?(Exception)
-        formatted_backtrace = msg.backtrace.join("\n")
+        formatted_backtrace = msg.backtrace&.join("\n")
         msg = "#{msg.class.name}, #{msg.message}\n#{formatted_backtrace}"
       end
 


### PR DESCRIPTION
#### 1. Stop logging all apnsp8 requests as warnings

The apnsp8 adapter currently logs the full request data for each individual notification with a log level of `warn`, which doesn't appear to be done for other service adapters in rpush. This leads to a lot of unnecessary logs at scale, and it could potentially expose private payload data in server logs in an undesired way.

This logging line was added in the initial PR that added apnsp8 support (#386, https://github.com/rpush/rpush/commit/3bc1929b98c0f29dd7fbca1ba0c8531fe879120e) – I suspect that it was added to help with initial implementation and debugging, and that it was left in as an oversight. I think it should be safe to remove, but please let me know if I've missed something. (And many thanks to the initial implementor for adding apnsp8 support!)

#### 2. Fix a memory leak

We send a large volume of APNS notifications per day, and when we switched from using `Rpush::Apns::Notification` to `Rpush::Apnsp8::Notification`, we saw a dramatic increase in memory usage by the daemon. Memory usage scales linearly as you send more messages – sending 100K messages made our memory usage grow by roughly 500MB. Eventually our rpush instance was forced to use swap memory to keep running, and deliveries ground to a halt.

We're not sure if this PR fully fixes the problem, but it was the first obvious leak that we could find. A new proc is allocated for every individual notification, and never released. We intend to run this modified version of rpush in production, and to continue investigating if we see any further issues.