### PR TITLE
Logging improvements

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -43,7 +43,6 @@ module Rpush
           response = {}
 
           request = build_request(notification)
-          log_warn(request)
           http_request = @client.prepare_request(:post, request[:path],
             body:    request[:body],
             headers: request[:headers]

--- a/lib/rpush/logger.rb
+++ b/lib/rpush/logger.rb
@@ -65,7 +65,7 @@ module Rpush
 
     def log(where, msg, inline = false, prefix = nil, io = STDOUT)
       if msg.is_a?(Exception)
-        formatted_backtrace = msg.backtrace.join("\n")
+        formatted_backtrace = msg.backtrace&.join("\n")
         msg = "#{msg.class.name}, #{msg.message}\n#{formatted_backtrace}"
       end
 


### PR DESCRIPTION
In the process of switching to the APNSp8 adapter, we noticed the following issues:

#### 1. Stop logging all apnsp8 requests as warnings
The apnsp8 adapter currently logs the full request data for each individual notification with a log level of `warn`, which doesn't appear to be done for other service adapters in rpush. This leads to a lot of unnecessary logs at scale, and it could potentially expose private payload data in server logs in an undesired way.

This logging line was added in the initial PR that added apnsp8 support (#386, [3bc1929](https://github.com/rpush/rpush/commit/3bc1929b98c0f29dd7fbca1ba0c8531fe879120e)) – I suspect that it was added to help with initial implementation and debugging, and that it was left in as an oversight. I think it should be safe to remove, but please let me know if I've missed something. (And many thanks to the initial implementor for adding apnsp8 support!)

#### 2. Don't crash when logging an unraised exception

When using the net-http2 gem, the NetHttp2::Client, can create a SocketError that does not get raised. 

https://github.com/ostinelli/net-http2/blob/4e566d6ac322fbd182a7b7948576b8c876f7333a/lib/net-http2/client.rb#L115

If we register a callback that logs this error, it will crash the rpush server because it doesn't have a backtrace.