### PR TITLE
Fix APNSp8 memory leak

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -17,8 +17,6 @@ module Rpush
         end
 
         def perform
-          @client.on(:error) { |err| mark_batch_retryable(Time.now + 10.seconds, err) }
-
           @batch.each_notification do |notification|
             prepare_async_post(notification)
           end

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -2,6 +2,8 @@ module Rpush
   module Daemon
     module Dispatcher
       class Apnsp8Http2
+        include Loggable
+        include Reflectable
 
         URLS = {
           production: 'https://api.push.apple.com',
@@ -14,18 +16,28 @@ module Rpush
           @app = app
           @delivery_class = delivery_class
 
-          url = URLS[app.environment.to_sym]
-          @client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_TIMEOUT)
+          @client = create_http2_client(app)
           @token_provider = Rpush::Daemon::Apnsp8::Token.new(@app)
         end
 
         def dispatch(payload)
-
           @delivery_class.new(@app, @client, @token_provider, payload.batch).perform
         end
 
         def cleanup
           @client.close
+        end
+
+        private
+
+        def create_http2_client(app)
+          url = URLS[app.environment.to_sym]
+          client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_TIMEOUT)
+          client.on(:error) do |error|
+            log_error(error)
+            reflect(:error, error)
+          end
+          client
         end
       end
     end


### PR DESCRIPTION
Along with #474, replaces #470 

We send a large volume of APNS notifications per day, and when we switched from using `Rpush::Apns::Notification` to `Rpush::Apnsp8::Notification`, we saw a dramatic increase in memory usage by the daemon. Memory usage scales linearly as you send more messages – sending 100K messages made our memory usage grow by roughly 500MB. Eventually our rpush instance was forced to use swap memory to keep running, and deliveries ground to a halt.

We are running this change in production and the memory usage is stable.