### PR TITLE
Fix memory leak by not attaching the batch to the http2 client

### DIFF
--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -15,8 +15,6 @@ module Rpush
         end
 
         def perform
-          @client.on(:error) { |err| mark_batch_retryable(Time.now + 10.seconds, err) }
-
           @batch.each_notification do |notification|
             prepare_async_post(notification)
           end


### PR DESCRIPTION
Similar to #475 

Closes #439 

We are using #475 (with #474 to avoid NoMethodErrors) in production but we do not use apns2.  Perhaps someone affected by #439 should test this out.

