### PR TITLE
Fail gracefully when a Modis notification no longer exists

### DIFF
--- a/spec/unit/daemon/store/redis_spec.rb
+++ b/spec/unit/daemon/store/redis_spec.rb
@@ -119,6 +119,7 @@ describe Rpush::Daemon::Store::Redis do
 
     it 'ignores IDs that do not exist without throwing an exception' do
       notification.destroy
+      expect(logger).to receive(:warn).with("Couldn't find Rpush::Client::Redis::Notification with id=#{notification.id}")
       expect do
         store.mark_ids_retryable([notification.id], deliver_after)
       end.not_to raise_exception
@@ -249,6 +250,7 @@ describe Rpush::Daemon::Store::Redis do
 
     it 'ignores IDs that do not exist without throwing an exception' do
       notification.destroy
+      expect(logger).to receive(:warn).with("Couldn't find Rpush::Client::Redis::Notification with id=#{notification.id}")
       expect do
         store.mark_ids_failed([notification.id], nil, '', Time.now)
       end.not_to raise_exception

--- a/spec/unit/daemon/store/redis_spec.rb
+++ b/spec/unit/daemon/store/redis_spec.rb
@@ -116,6 +116,13 @@ describe Rpush::Daemon::Store::Redis do
         notification.reload
       end.to change { notification.deliver_after.try(:utc).to_s }.to(deliver_after.utc.to_s)
     end
+
+    it 'ignores IDs that do not exist without throwing an exception' do
+      notification.destroy
+      expect do
+        store.mark_ids_retryable([notification.id], deliver_after)
+      end.not_to raise_exception
+    end
   end
 
   describe 'mark_batch_retryable' do
@@ -238,6 +245,13 @@ describe Rpush::Daemon::Store::Redis do
         store.mark_ids_failed([notification.id], nil, '', Time.now)
         notification.reload
       end.to change(notification, :failed).to(true)
+    end
+
+    it 'ignores IDs that do not exist without throwing an exception' do
+      notification.destroy
+      expect do
+        store.mark_ids_failed([notification.id], nil, '', Time.now)
+      end.not_to raise_exception
     end
   end
 


### PR DESCRIPTION
This makes behavior more consistent with the ActiveRecord adapter. If a service attempts to call #mark_ids_retryable or #mark_ids_failed and includes an ID that no longer exists in the datastore, the adapter will simply skip that record and continue, rather than crashing. (Currently, the adapter crashes, which can cause delivery issues with other unrelated notifications.)