### PR TITLE
Add mutable_content support for GCM

### DIFF
--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -43,6 +43,7 @@ module Rpush
             }
             json['collapse_key'] = collapse_key if collapse_key
             json['content_available'] = content_available if content_available
+            json['mutable_content'] = mutable_content if mutable_content
             json['dry_run'] = dry_run if dry_run
             json['notification'] = notification if notification
             json['priority'] = priority_for_notification if priority

--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -35,7 +35,7 @@ module Rpush
             end
           end
 
-          def as_json(options = nil)
+          def as_json(options = nil) # rubocop:disable Metrics/PerceivedComplexity
             json = {
                 'registration_ids' => registration_ids,
                 'delay_while_idle' => delay_while_idle,

--- a/spec/unit/client/active_record/gcm/notification_spec.rb
+++ b/spec/unit/client/active_record/gcm/notification_spec.rb
@@ -37,6 +37,11 @@ describe Rpush::Client::ActiveRecord::Gcm::Notification do
     expect(notification.as_json['content_available']).to eq true
   end
 
+  it 'includes mutable_content in the payload' do
+    notification.mutable_content = true
+    expect(notification.as_json['mutable_content']).to eq true
+  end
+
   it 'sets the priority to high when set to high' do
     notification.priority = 'high'
     expect(notification.as_json['priority']).to eq 'high'


### PR DESCRIPTION
https://firebase.google.com/docs/cloud-messaging/http-server-ref

Currently it doesn't send `mutable_content` option to firebase server