### PR TITLE
Update apns_http2.rb

### DIFF
--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -2,7 +2,9 @@ module Rpush
   module Daemon
     module Dispatcher
       class ApnsHttp2
-
+        include Loggable
+        include Reflectable
+        
         URLS = {
           production: 'https://api.push.apple.com:443',
           development: 'https://api.development.push.apple.com:443',

--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -4,7 +4,7 @@ module Rpush
       class ApnsHttp2
         include Loggable
         include Reflectable
-        
+
         URLS = {
           production: 'https://api.push.apple.com:443',
           development: 'https://api.development.push.apple.com:443',


### PR DESCRIPTION
Fixed issue [ERROR] NoMethodError, undefined method `log_error' for #<Rpush::Daemon::Dispatcher::ApnsHttp2:0x0055ef9bf4fc78> thrown while rpush daemon started