### PR TITLE
Correctly use feedback_enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix disabling APNS feedback for specific Rpush apps [#511](https://github.com/rpush/rpush/pull/511) (by [@kirbydcool](https://github.com/kirbydcool))
+
 ## 4.1.1 (2019-05-13)
 
 ### Added

--- a/lib/rpush/daemon/apns/feedback_receiver.rb
+++ b/lib/rpush/daemon/apns/feedback_receiver.rb
@@ -24,6 +24,7 @@ module Rpush
 
         def start
           return if Rpush.config.push
+          return unless @app.feedback_enabled
           Rpush.logger.info("[#{@app.name}] Starting feedback receiver... ", true)
 
           @thread = Thread.new do

--- a/spec/unit/daemon/apns/feedback_receiver_spec.rb
+++ b/spec/unit/daemon/apns/feedback_receiver_spec.rb
@@ -7,7 +7,16 @@ describe Rpush::Daemon::Apns::FeedbackReceiver, 'check_for_feedback' do
   let(:frequency) { 60 }
   let(:certificate) { double }
   let(:password) { double }
-  let(:app) { double(name: 'my_app', password: password, certificate: certificate, environment: 'production') }
+  let(:feedback_enabled) { true }
+  let(:app) do
+    double(
+      name: 'my_app',
+      password: password,
+      certificate: certificate,
+      feedback_enabled: feedback_enabled,
+      environment: 'production'
+    )
+  end
   let(:connection) { double(connect: nil, read: nil, close: nil) }
   let(:logger) { double(error: nil, info: nil) }
   let(:receiver) { Rpush::Daemon::Apns::FeedbackReceiver.new(app) }
@@ -92,6 +101,15 @@ describe Rpush::Daemon::Apns::FeedbackReceiver, 'check_for_feedback' do
     it 'checks for feedback when started' do
       expect(receiver).to receive(:check_for_feedback).at_least(:once)
       receiver.start
+    end
+
+    context 'with feedback_enabled false' do
+      let(:feedback_enabled) { false }
+
+      it 'does not check for feedback when started' do
+        expect(receiver).not_to receive(:check_for_feedback)
+        receiver.start
+      end
     end
   end
 


### PR DESCRIPTION
The main entrypoint for the apns feedback receiver is calling its `.start` method. We need to check the `feedback_enabled` attribute there.

Fixes issue introduced here https://github.com/rpush/rpush/pull/491