### PR TITLE
 Handle GCM reflections in batches.

### DIFF
--- a/lib/generators/templates/rpush.rb
+++ b/lib/generators/templates/rpush.rb
@@ -29,6 +29,17 @@ Rpush.configure do |config|
   # config.apns.feedback_receiver.enabled = true
   # config.apns.feedback_receiver.frequency = 60
 
+  # Allow GCM reflections to return batch results
+  # setting this option skips calling gcm_delivered_to_recipient, :gcm_failed_to_recipient,
+  # :gcm_canonical_id, :gcm_invalid_registration_id and calls plural :gcm reflections
+  # :gcm_delivered_to_recipients and :gcm_failed_to_recipients instead
+  # config.gcm_batch_reflections = true
+
+  # Allow batches to reflect per-notification :notification_delivered, :notification_failed,
+  # :notification_will_retry by bulk reflections :notifications_delivered, :notifications_failed and
+  # :notifications_will_retry
+  # config.notification_batch_reflections = true
+
 end
 
 Rpush.reflect do |on|
@@ -59,6 +70,15 @@ Rpush.reflect do |on|
   # on.notification_failed do |notification|
   # end
 
+  # Called when notifications are successfully delivered and config.notification_batch_reflections is set.
+  # on.notifications_delivered do |notifications|
+  # end
+
+  # Called when notifications delivery failed and config.notification_batch_reflections is set.
+  # Call 'error_code' and 'error_description' on the notification for the cause.
+  # on.notifications_failed do |notifications|
+  # end
+
   # Called when the notification delivery failed and only the notification ID
   # is present in memory.
   # on.notification_id_failed do |app, notification_id, error_code, error_description|
@@ -68,6 +88,10 @@ Rpush.reflect do |on|
   # Call 'deliver_after' on the notification for the next delivery date
   # and 'retries' for the number of times this notification has been retried.
   # on.notification_will_retry do |notification|
+  # end
+
+  # Called when notifications will be retried at a later date and config.notification_batch_reflections is set.
+  # on.notifications_will_retry do |notifications|
   # end
 
   # Called when a notification will be retried and only the notification ID
@@ -99,6 +123,21 @@ Rpush.reflect do |on|
   # Called when the GCM returns a failure that indicates an invalid registration id.
   # You will need to delete the registration_id from your records.
   # on.gcm_invalid_registration_id do |app, error, registration_id|
+  # end
+
+  # When configuration option :gcm_batch_reflections is set
+  # reflection would use only plural gcm reflections
+  # successes_map is a map of registration_id to canonical_id (if id replace is required, else nil)
+  # { token1 => canonical_token, token2 => nil, token3 => nil, ... }
+  # on.gcm_delivered_to_recipients do |notification, successes_map|
+  # end
+  #
+  # failures map is a map of registration_id to failure hash
+  # unavailable and invalid states are set as keys (:invalid and :unavailable) in the failure hash
+  # { token4 => { error: 'NotRegistered', invalid: true },
+  #   token5 => { error: 'InvalidRegistration', invalid: true },
+  #   token6 => { error: 'Unavailable', unavailable: true } }
+  # on.gcm_failed_to_recipients do |notification, failures_map|
   # end
 
   # Called when an SSL certificate will expire within 1 month.

--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -16,7 +16,8 @@ module Rpush
     end
   end
 
-  CURRENT_ATTRS = [:push_poll, :embedded, :pid_file, :batch_size, :push, :client, :logger, :log_file, :foreground, :log_level, :plugin, :apns]
+  CURRENT_ATTRS = [:push_poll, :embedded, :pid_file, :batch_size, :push, :client, :logger, :log_file, :foreground,
+                   :log_level, :plugin, :apns, :gcm_batch_reflections, :notification_batch_reflections]
   DEPRECATED_ATTRS = []
   CONFIG_ATTRS = CURRENT_ATTRS + DEPRECATED_ATTRS
 
@@ -53,6 +54,8 @@ module Rpush
       self.log_level = (defined?(Rails) && Rails.logger) ? Rails.logger.level : ::Logger::Severity::DEBUG
       self.plugin = OpenStruct.new
       self.foreground = false
+      self.gcm_batch_reflections = false
+      self.notification_batch_reflections = false
 
       self.apns = ApnsConfiguration.new
 

--- a/lib/rpush/reflection_collection.rb
+++ b/lib/rpush/reflection_collection.rb
@@ -8,7 +8,9 @@ module Rpush
       :gcm_failed_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
       :error, :adm_canonical_id, :adm_failed_to_recipient, :wns_invalid_channel,
       :tcp_connection_lost, :ssl_certificate_will_expire, :ssl_certificate_revoked,
-      :notification_id_will_retry, :notification_id_failed
+      :notification_id_will_retry, :notification_id_failed,
+      :gcm_delivered_to_recipients, :gcm_failed_to_recipients,
+      :notifications_delivered, :notifications_failed, :notifications_will_retry
     ]
 
     DEPRECATIONS = {}

--- a/spec/support/simplecov_helper.rb
+++ b/spec/support/simplecov_helper.rb
@@ -18,7 +18,7 @@ module SimpleCovHelper
         end
       end
 
-      formatter SimpleCov::Formatter::MultiFormatter[*formatters]
+      formatter SimpleCov::Formatter::MultiFormatter.new(*formatters)
     end
   end
 end

--- a/spec/unit/daemon/gcm/results_spec.rb
+++ b/spec/unit/daemon/gcm/results_spec.rb
@@ -1,0 +1,32 @@
+require 'unit_spec_helper'
+
+RSpec.describe Rpush::Daemon::Gcm::Results do
+  let(:results_data) do
+    [
+      { 'message_id' => 'm1' },
+      { 'message_id' => 'm1', 'registration_id' => 'asd-x-canonical-2' },
+      { 'error' => 'InvalidRegistration' },
+      { 'error' => 'BadGateway' },
+      { 'error' => 'The truth is out there' }
+    ]
+  end
+  let(:registration_ids) { %w[asd asd2 fail fail2 fail3] }
+  let(:failure_partitions) do
+    { invalid: Rpush::Daemon::Gcm::Delivery::INVALID_REGISTRATION_ID_STATES,
+      unavailable: Rpush::Daemon::Gcm::Delivery:: UNAVAILABLE_STATES }
+  end
+  let(:failure_result) do
+    f = Rpush::Daemon::Gcm::Failures.new
+    f << { registration_id: 'fail', index: 2, error: 'InvalidRegistration', invalid: true }
+    f << { registration_id: 'fail2', index: 3, error: 'BadGateway', unavailable: true }
+    f << { registration_id: 'fail3', index: 4, error: 'The truth is out there' }
+    f
+  end
+
+  subject { described_class.new(results_data, registration_ids) }
+
+  it 'returns failures with failure categories set within' do
+    subject.process(failure_partitions)
+    expect(subject.failures.map(&:itself)).to eq(failure_result.map(&:itself))
+  end
+end


### PR DESCRIPTION
Since we push messages to GCM in a batch and the response comes with each registration_id delivery status, there is no need to reflect each device separately. This feature allows to receive all successful and failed statues per single reflection.
```ruby
# example usage
Rpush.configure do |config|
  config.gcm_batch_reflections = true
end
Rpush.reflect do |on|
  on.gcm_delivered_to_recipients do |notification, successes_map|
    success_values = successes_map.keys.map { |token| [notification.id, token] }
    DeviceDeliveryStatus.import %i[notification_id device_token], success_values
  end
end
```