### PR TITLE
Update development apns urls to match documentation

### DIFF
--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -5,8 +5,8 @@ module Rpush
 
         URLS = {
           production: 'https://api.push.apple.com:443',
-          development: 'https://api.development.push.apple.com:443',
-          sandbox: 'https://api.development.push.apple.com:443'
+          development: 'https://api.sandbox.push.apple.com:443',
+          sandbox: 'https://api.sandbox.push.apple.com:443'
         }
 
         DEFAULT_TIMEOUT = 60

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -7,7 +7,7 @@ module Rpush
 
         URLS = {
           production: 'https://api.push.apple.com',
-          development: 'https://api.development.push.apple.com'
+          development: 'https://api.sandbox.push.apple.com',
         }
 
         DEFAULT_TIMEOUT = 60

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -8,6 +8,7 @@ module Rpush
         URLS = {
           production: 'https://api.push.apple.com',
           development: 'https://api.sandbox.push.apple.com',
+          sandbox: 'https://api.sandbox.push.apple.com'
         }
 
         DEFAULT_TIMEOUT = 60


### PR DESCRIPTION
As documented [here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns), the development apns2 url is at `api.sandbox.push.apple.com`

This should be a seamless change as development points to the sandbox url:
```bash
$ nslookup api.development.push.apple.com
Server:		192.168.1.1
Address:	192.168.1.1#53

Non-authoritative answer:
api.development.push.apple.com	canonical name = api.sandbox.push-apple.com.akadns.net.
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.166.27
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.166.29
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.165.218
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.165.219

$ nslookup api.sandbox.push.apple.com
Server:		192.168.1.1
Address:	192.168.1.1#53

Non-authoritative answer:
api.sandbox.push.apple.com	canonical name = api.sandbox.push-apple.com.akadns.net.
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.166.27
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.166.29
Update development apns urls to match documentation
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.165.219
Name:	api.sandbox.push-apple.com.akadns.net
Address: 17.188.165.218
```