### PR TITLE
GCM notification incorrectly mixes data into notification hashes

### DIFF
--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -21,7 +21,7 @@ module Rpush
         def notification=(attrs)
           return unless attrs
           fail ArgumentError, 'must be a Hash' unless attrs.is_a?(Hash)
-          write_attribute(:notification, multi_json_dump(attrs.merge(data || {})))
+          write_attribute(:notification, multi_json_dump(attrs.merge(notification || {})))
         end
 
         def registration_ids=(ids)

--- a/spec/unit/client/active_record/notification_spec.rb
+++ b/spec/unit/client/active_record/notification_spec.rb
@@ -18,4 +18,11 @@ describe Rpush::Client::ActiveRecord::Notification do
     expect(notification.app).to be_valid
     expect(notification).to be_valid
   end
+
+  it 'does not mix notification and data payloads' do
+    notification.data = { key: 'this is data' }
+    notification.notification = { key: 'this is notification' }
+    expect(notification.data).to eq('key' => 'this is data')
+    expect(notification.notification).to eq('key' => 'this is notification')
+  end
 end if active_record?


### PR DESCRIPTION
**Describe the bug**
The current implementation of GCM notifications merges the data payload into the notification payload, instead of the original notification payload. I assume this error was introduced when the data methods were duplicated, but the attribute merged back was not adjusted.

Error appears to originate from this line:
https://github.com/rpush/rpush/blob/master/lib/rpush/client/active_record/notification.rb#L24

This actually affects all notification classes, not only GCM, but i think only GCM uses the notification attribute.

**To Reproduce**
Create a new GCM/Firebase notification, first define data then notification. Notification will include the has defined in data. If you first define the notification and then data, it will work as expected (as data hash is still empty when setting notification).

```ruby
record = Rpush::Gcm::Notification.new
record.data = {'data' => 'data'}
record.notification = {'body' => 'body', 'title' => 'title'}

record.data # {"data"=>"data"}
record.notification # {"body"=>"body", "title"=>"title", "data"=>"data"} 
```

vs

```ruby
record = Rpush::Gcm::Notification.new
record.notification = {'body' => 'body', 'title' => 'title'}
record.data = {'data' => 'data'}

record.data # {"data"=>"data"}
record.notification # {"body"=>"body", "title"=>"title"} 
```

**Expected behaviour**
See second ruby examples from above. The order in which the methods are used should not change the outcome.