### PR TITLE
Fix GCM priority when using Redis

### DIFF
--- a/lib/rpush/client/active_model/gcm/notification.rb
+++ b/lib/rpush/client/active_model/gcm/notification.rb
@@ -26,9 +26,9 @@ module Rpush
           # I'm not happy about it, but this will have to do until I can take a further look.
           def priority=(priority)
             case priority
-              when 'high'
+              when 'high', GCM_PRIORITY_HIGH
                 super(GCM_PRIORITY_HIGH)
-              when 'normal'
+              when 'normal', GCM_PRIORITY_NORMAL
                 super(GCM_PRIORITY_NORMAL)
               else
                 errors.add(:priority, 'must be one of either "normal" or "high"')

--- a/spec/functional/gcm_priority_spec.rb
+++ b/spec/functional/gcm_priority_spec.rb
@@ -1,0 +1,40 @@
+require 'functional_spec_helper'
+
+describe 'GCM priority' do
+  let(:app) { Rpush::Gcm::App.new }
+  let(:notification) { Rpush::Gcm::Notification.new }
+  let(:hydrated_notification) { Rpush::Gcm::Notification.find(notification.id) }
+  let(:response) { double(Net::HTTPResponse, code: 200) }
+  let(:http) { double(Net::HTTP::Persistent, request: response, shutdown: nil) }
+  let(:priority) { 'normal' }
+
+  before do
+    app.name = 'test'
+    app.auth_key = 'abc123'
+    app.save!
+
+    notification.app_id = app.id
+    notification.registration_ids = ['foo']
+    notification.data = { message: 'test' }
+    notification.priority = priority
+    notification.save!
+
+    allow(Net::HTTP::Persistent).to receive_messages(new: http)
+  end
+
+  it 'supports normal priority' do
+    expect(hydrated_notification.as_json['priority']).to eq('normal')
+  end
+
+  context 'high priority' do
+    let(:priority) { 'high' }
+
+    it 'supports high priority' do
+      expect(hydrated_notification.as_json['priority']).to eq('high')
+    end
+  end
+
+  it 'does not add an error when receiving expected priority' do
+    expect(hydrated_notification.errors.messages[:priority]).to be_empty
+  end
+end


### PR DESCRIPTION
Run new specs with Redis client:
CLIENT=redis BUNDLE_GEMFILE=gemfiles/rails_5.2.gemfile rspec spec/functional/gcm_priority_spec.rb

Addresses https://github.com/rpush/rpush/issues/260