### PR TITLE
Improve DB reconnection for big tables

### DIFF
--- a/lib/rpush/daemon/store/active_record/reconnectable.rb
+++ b/lib/rpush/daemon/store/active_record/reconnectable.rb
@@ -67,7 +67,7 @@ module Rpush
 
           def check_database_is_connected
             # Simply asking the adapter for the connection state is not sufficient.
-            Rpush::Client::ActiveRecord::Notification.count
+            Rpush::Client::ActiveRecord::Notification.exists?
           end
 
           def sleep_to_avoid_thrashing

--- a/spec/unit/daemon/store/active_record/reconnectable_spec.rb
+++ b/spec/unit/daemon/store/active_record/reconnectable_spec.rb
@@ -80,8 +80,8 @@ describe Rpush::Daemon::Store::ActiveRecord::Reconnectable do
     test_doubles.each(&:perform)
   end
 
-  it "should test out the new connection by performing a count" do
-    expect(Rpush::Client::ActiveRecord::Notification).to receive(:count).twice
+  it "should test out the new connection by performing an exists" do
+    expect(Rpush::Client::ActiveRecord::Notification).to receive(:exists?).twice
     test_doubles.each(&:perform)
   end
 
@@ -118,13 +118,13 @@ describe Rpush::Daemon::Store::ActiveRecord::Reconnectable do
   context "when the reconnection attempt is not successful" do
     before do
       class << Rpush::Client::ActiveRecord::Notification
-        def count
-          @count_calls += 1
-          return if @count_calls == 2
+        def exists?
+          @exists_calls += 1
+          return if @exists_calls == 2
           fail @error
         end
       end
-      Rpush::Client::ActiveRecord::Notification.instance_variable_set("@count_calls", 0)
+      Rpush::Client::ActiveRecord::Notification.instance_variable_set("@exists_calls", 0)
       Rpush::Client::ActiveRecord::Notification.instance_variable_set("@error", error)
     end
 
@@ -152,7 +152,7 @@ describe Rpush::Daemon::Store::ActiveRecord::Reconnectable do
       end
 
       it "should log errors raised when the reconnection is not successful" do
-        expect(Rpush.logger).to receive(:error).with(error)
+        expect(Rpush.logger).to receive(:error).with(timeout)
         test_doubles[1].perform
       end
 


### PR DESCRIPTION
Using `.count` for checking if DB connected can produce significant load on big tables. This commit simply replaces it by `.exists?`.

<img width="1185" alt="Screenshot 2020-09-24 at 12 36 04" src="https://user-images.githubusercontent.com/2176335/94128349-b8dd9180-fe62-11ea-931f-8c3e1e54c298.png">

![image (1)](https://user-images.githubusercontent.com/2176335/94128357-bc711880-fe62-11ea-9055-036fc8ac56ab.png)


