### PR TITLE
Resume APNS2 delivery when async requests timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       jwt (>= 1.5.6)
       multi_json (~> 1.0)
       net-http-persistent
-      net-http2 (~> 0.14)
+      net-http2 (~> 0.18, >= 0.18.3)
       railties
       rainbow
       thor (>= 0.18.1, < 2.0)
@@ -51,13 +51,13 @@ GEM
     docile (1.3.1)
     erubi (1.9.0)
     hiredis (0.6.3)
-    http-2 (0.10.1)
+    http-2 (0.10.2)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.1)
-    jwt (2.2.1)
-    loofah (2.6.0)
+    jwt (2.2.2)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
@@ -71,13 +71,13 @@ GEM
       msgpack (>= 0.5)
       redis (>= 3.0)
     msgpack (1.3.1)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     mysql2 (0.5.2)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
-    net-http2 (0.18.2)
+    net-http2 (0.18.3)
       http-2 (~> 0.10.1)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -164,4 +164,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -7,6 +7,7 @@ module Rpush
 
       class Delivery < Rpush::Daemon::Delivery
         RETRYABLE_CODES = [ 429, 500, 503 ]
+        CLIENT_JOIN_TIMEOUT = 60
 
         def initialize(app, http2_client, batch)
           @app = app
@@ -20,7 +21,11 @@ module Rpush
           end
 
           # Send all preprocessed requests at once
-          @client.join
+          @client.join(timeout: CLIENT_JOIN_TIMEOUT)
+        rescue NetHttp2::AsyncRequestTimeout => error
+          mark_batch_retryable(Time.now + 10.seconds, error)
+          @client.close
+          raise
         rescue Errno::ECONNREFUSED, SocketError => error
           mark_batch_retryable(Time.now + 10.seconds, error)
           raise

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'multi_json', '~> 1.0'
   s.add_runtime_dependency 'net-http-persistent'
-  s.add_runtime_dependency 'net-http2', '~> 0.14'
+  s.add_runtime_dependency 'net-http2', '~> 0.18', '>= 0.18.3'
   s.add_runtime_dependency 'jwt', '>= 1.5.6'
   s.add_runtime_dependency 'activesupport', '>= 5.0'
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']


### PR DESCRIPTION
Sometimes an async APNSv2 request's response will not be received.

Previously, rpush would wait indefinitely for this and continue pulling notifications out of the pending queue in redis to queue them in memory. Since the response never comes, this in-memory queue is not worked any further, the process gets stuck and will not cleanly shut down, requiring a SIGKILL. Those notifications queued in memory will forever remain in redis in a checked-out state such that the new rpush instance that replaces the hung one won't pick them up, and they'll thus never be sent.

This change not only retries sending the batch which was never fully confirmed as having been sent, but also ensures that processing of the in-memory queue continues past that batch, which in turn allows a shutdown to proceed smoothly, if slowly.

Fixes #477.

Based on https://github.com/ostinelli/net-http2/pull/43