### PR TITLE
Do not retry notifications which already have been delivered/failed

### DIFF
--- a/lib/rpush/daemon/batch.rb
+++ b/lib/rpush/daemon/batch.rb
@@ -27,19 +27,19 @@ module Rpush
       end
 
       def mark_retryable(notification, deliver_after)
+        return if notification.delivered || notification.failed
+
         @mutex.synchronize do
           @retryable[deliver_after] ||= []
           @retryable[deliver_after] << notification
         end
+
         Rpush::Daemon.store.mark_retryable(notification, deliver_after, persist: false)
       end
 
       def mark_all_retryable(deliver_after)
-        @mutex.synchronize do
-          @retryable[deliver_after] = @notifications
-        end
         each_notification do |notification|
-          Rpush::Daemon.store.mark_retryable(notification, deliver_after, persist: false)
+          mark_retryable(notification, deliver_after)
         end
       end
 

--- a/lib/rpush/daemon/delivery.rb
+++ b/lib/rpush/daemon/delivery.rb
@@ -20,8 +20,7 @@ module Rpush
       end
 
       def mark_batch_retryable(deliver_after, error)
-        log_warn("Will retry #{@batch.notifications.size} notifications after #{deliver_after.strftime('%Y-%m-%d %H:%M:%S')} due to error (#{error.class.name}, #{error.message})")
-        @batch.mark_all_retryable(deliver_after)
+        @batch.mark_all_retryable(deliver_after, error)
       end
 
       def mark_delivered

--- a/spec/unit/daemon/delivery_spec.rb
+++ b/spec/unit/daemon/delivery_spec.rb
@@ -41,6 +41,16 @@ describe Rpush::Daemon::Delivery do
     end
   end
 
+  describe 'mark_batch_retryable' do
+    let(:batch) { double(Rpush::Daemon::Batch) }
+    let(:error) { StandardError.new('Exception') }
+
+    it 'marks all notifications as retryable' do
+      expect(batch).to receive(:mark_all_retryable)
+      delivery.mark_batch_retryable(Time.now + 1.hour, error)
+    end
+  end
+
   describe 'mark_batch_failed' do
     it 'marks all notifications as delivered' do
       error = Rpush::DeliveryError.new(1, 42, 'an error')


### PR DESCRIPTION
If an issue happens in the middle of a request, do not mark already sent/failed notifications for retry.

This is part of an error log

```ruby
I, [2020-09-25T13:08:03.210427 #78207]  INFO -- : [2020-09-25 13:08:03] [test] 1 sent to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
[2020-09-25 13:08:03] [WARNING] [test] Will retry 1 notifications after 2020-09-25 13:08:13 due to error (SocketError, SocketError)
W, [2020-09-25T13:08:03.210714 #78207]  WARN -- : [2020-09-25 13:08:03] [WARNING] [test] Will retry 1 notifications after 2020-09-25 13:08:13 due to error (SocketError, SocketError)
D, [2020-09-25T13:08:03.211708 #78207] DEBUG -- :    (2.1ms)  SELECT COUNT(*) FROM "rpush_notifications" WHERE (processing = FALSE AND delivered = FALSE AND failed = FALSE AND (deliver_after IS NULL OR deliver_after < '2020-09-25 10:08:03.209164'))
D, [2020-09-25T13:08:03.240860 #78207] DEBUG -- :   Rpush::Client::ActiveRecord::Notification Update All (3.0ms)  UPDATE "rpush_notifications" SET processing = FALSE, delivered = TRUE, delivered_at = '2020-09-25 10:08:03.210821' WHERE "rpush_notifications"."id" = $1  [["id", 1]]
D, [2020-09-25T13:08:03.244818 #78207] DEBUG -- :   Rpush::Client::ActiveRecord::Notification Update All (2.1ms)  UPDATE "rpush_notifications" SET processing = FALSE, delivered = FALSE, delivered_at = NULL, failed = FALSE, failed_at = NULL, retries = retries + 1, deliver_after = '2020-09-25 10:08:13.210631' WHERE "rpush_notifications"."id" = $1  [["id", 1]]
[2020-09-25 13:08:03] [ERROR] SocketError, SocketError
```

You can see two updates of the same notification there. 

We have two types of "callbacks", callbacks per particular async post inside `handle_response`

```ruby
 # lib/rpush/daemon/apnsp8/delivery.rb

def ok(notification)
  log_info("#{notification.id} sent to #{notification.device_token}")
  @batch.mark_delivered(notification)
end
```

Which puts this notification inside `@delivered` array of a `@batch` when async post was completed for particular notification. And `rescue` for the whole connection inside `perform`

```ruby
 # lib/rpush/daemon/apnsp8/delivery.rb

rescue Errno::ECONNREFUSED, SocketError, HTTP2::Error::StreamLimitExceeded => error
  # TODO restart connection when StreamLimitExceeded
  mark_batch_retryable(Time.now + 10.seconds, error)
```
Which puts the whole bunch of notifications inside `@retryable` array of a `@batch`. And as result the same notification appears in both collections.