### PR TITLE
Reference current interface in config template

### DIFF
--- a/lib/generators/templates/rpush.rb
+++ b/lib/generators/templates/rpush.rb
@@ -42,10 +42,7 @@ Rpush.reflect do |on|
   # Called when a notification is queued internally for delivery.
   # The internal queue for each app runner can be inspected:
   #
-  # Rpush::Daemon::AppRunner.runners.each do |app_id, runner|
-  #   runner.app
-  #   runner.queue_size
-  # end
+  # Rpush::Daemon::AppRunner.status
   #
   # on.notification_enqueued do |notification|
   # end


### PR DESCRIPTION
Fixes #526, which was broken by https://github.com/rpush/rpush/commit/f2a3c23f5b6644d602307f5f82789fcf9879f651