### PR TITLE
Allow opting out of foreground stdout logging

### DIFF
--- a/lib/generators/templates/rpush.rb
+++ b/lib/generators/templates/rpush.rb
@@ -26,6 +26,10 @@ Rpush.configure do |config|
   # Define a custom logger.
   # config.logger = MyLogger.new
 
+  # By default in foreground mode logs are directed both to the logger and to stdout.
+  # If the logger goes to stdout, you can disable foreground logging to avoid duplication.
+  # config.foreground_logging = false
+
   # config.apns.feedback_receiver.enabled = true
   # config.apns.feedback_receiver.frequency = 60
 

--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -16,7 +16,7 @@ module Rpush
     end
   end
 
-  CURRENT_ATTRS = [:push_poll, :embedded, :pid_file, :batch_size, :push, :client, :logger, :log_file, :foreground, :log_level, :plugin, :apns]
+  CURRENT_ATTRS = [:push_poll, :embedded, :pid_file, :batch_size, :push, :client, :logger, :log_file, :foreground, :foreground_logging, :log_level, :plugin, :apns]
   DEPRECATED_ATTRS = []
   CONFIG_ATTRS = CURRENT_ATTRS + DEPRECATED_ATTRS
 
@@ -53,6 +53,7 @@ module Rpush
       self.log_level = (defined?(Rails) && Rails.logger) ? Rails.logger.level : ::Logger::Severity::DEBUG
       self.plugin = OpenStruct.new
       self.foreground = false
+      self.foreground_logging = true
 
       self.apns = ApnsConfiguration.new
 

--- a/lib/rpush/daemon.rb
+++ b/lib/rpush/daemon.rb
@@ -109,7 +109,7 @@ module Rpush
         Feeder.stop
         AppRunner.stop
         delete_pid_file
-        puts Rainbow('✔').red if Rpush.config.foreground
+        puts Rainbow('✔').red if Rpush.config.foreground && Rpush.config.foreground_logging
       end
     end
 

--- a/lib/rpush/daemon/apns/feedback_receiver.rb
+++ b/lib/rpush/daemon/apns/feedback_receiver.rb
@@ -37,7 +37,7 @@ module Rpush
             Rpush::Daemon.store.release_connection
           end
 
-          puts Rainbow('✔').green if Rpush.config.foreground
+          puts Rainbow('✔').green if Rpush.config.foreground && Rpush.config.foreground_logging
         end
 
         def stop

--- a/lib/rpush/daemon/app_runner.rb
+++ b/lib/rpush/daemon/app_runner.rb
@@ -29,7 +29,7 @@ module Rpush
         Rpush.logger.info("[#{app.name}] Starting #{pluralize(app.connections, 'dispatcher')}... ", true)
         runner = @runners[app.id] = new(app)
         runner.start_dispatchers
-        puts Rainbow('✔').green if Rpush.config.foreground
+        puts Rainbow('✔').green if Rpush.config.foreground && Rpush.config.foreground_logging
         runner.start_loops
       rescue StandardError => e
         @runners.delete(app.id)

--- a/lib/rpush/logger.rb
+++ b/lib/rpush/logger.rb
@@ -79,6 +79,7 @@ module Rpush
     end
 
     def log_foreground(io, formatted_msg, inline)
+      return unless Rpush.config.foreground_logging
       return unless io == STDERR || Rpush.config.foreground
 
       if inline


### PR DESCRIPTION
By default in foreground mode logs are directed both to the logger and to stdout. If the logger goes to stdout, you can disable foreground logging to avoid duplication.
