### PR TITLE
support for Webpush with VAPID

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       railties
       rainbow
       thor (>= 0.18.1, < 2.0)
+      webpush (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -51,6 +52,7 @@ GEM
     docile (1.3.1)
     erubi (1.9.0)
     hiredis (0.6.3)
+    hkdf (0.3.0)
     http-2 (0.10.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -140,6 +142,9 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
+    webpush (1.0.0)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
 
 PLATFORMS
   ruby

--- a/lib/rpush/client/active_model.rb
+++ b/lib/rpush/client/active_model.rb
@@ -32,3 +32,6 @@ require 'rpush/client/active_model/wns/notification'
 require 'rpush/client/active_model/pushy/app'
 require 'rpush/client/active_model/pushy/notification'
 require 'rpush/client/active_model/pushy/time_to_live_validator'
+
+require 'rpush/client/active_model/webpush/app'
+require 'rpush/client/active_model/webpush/notification'

--- a/lib/rpush/client/active_model/webpush/app.rb
+++ b/lib/rpush/client/active_model/webpush/app.rb
@@ -1,0 +1,41 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Webpush
+        module App
+
+          class VapidKeypairValidator < ::ActiveModel::Validator
+            def validate(record)
+              return if record.vapid_keypair.blank?
+              keypair = record.vapid
+              %i[ subject public_key private_key ].each do |key|
+                unless keypair.key?(key)
+                  record.errors.add(:vapid_keypair, "must have a #{key} entry")
+                end
+              end
+            rescue
+              record.errors.add(:vapid_keypair, 'must be valid JSON')
+            end
+          end
+
+          def self.included(base)
+            base.class_eval do
+              alias_attribute :vapid_keypair, :certificate
+              validates :vapid_keypair, presence: true
+              validates_with VapidKeypairValidator
+            end
+          end
+
+          def service_name
+            'webpush'
+          end
+
+          def vapid
+            @vapid ||= JSON.parse(vapid_keypair).symbolize_keys
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/webpush/notification.rb
+++ b/lib/rpush/client/active_model/webpush/notification.rb
@@ -1,0 +1,66 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Webpush
+        module Notification
+
+          class RegistrationValidator < ::ActiveModel::Validator
+            KEYS = %i[ endpoint keys ].freeze
+            def validate(record)
+              return if record.registration_ids.blank?
+              return if record.registration_ids.size > 1
+              reg = record.registration_ids.first
+              unless reg.is_a?(Hash) &&
+                  reg.keys.sort == KEYS &&
+                  reg[:endpoint].is_a?(String) &&
+                  reg[:keys].is_a?(Hash)
+                record.errors.add(:base, 'Registration must have :endpoint (String) and :keys (Hash) keys')
+              end
+            end
+          end
+
+          def self.included(base)
+            base.instance_eval do
+              alias_attribute :time_to_live, :expiry
+
+              validates :registration_ids, presence: true
+              validates :data, presence: true
+              validates :time_to_live, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
+              validates_with Rpush::Client::ActiveModel::PayloadDataSizeValidator, limit: 4096
+              validates_with Rpush::Client::ActiveModel::RegistrationIdsCountValidator, limit: 1
+              validates_with RegistrationValidator
+            end
+          end
+
+          def data=(value)
+            value = value.stringify_keys if value.respond_to?(:stringify_keys)
+            super value
+          end
+
+          def subscription
+            @subscription ||= registration_ids.first.deep_symbolize_keys
+          end
+
+          def message
+            data['message'].presence if data
+          end
+
+          # https://webpush-wg.github.io/webpush-protocol/#urgency
+          def urgency
+            data['urgency'].presence if data
+          end
+
+          def as_json(_options = nil)
+            {
+              'data'             => data,
+              'time_to_live'     => time_to_live,
+              'registration_ids' => registration_ids
+            }
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record.rb
+++ b/lib/rpush/client/active_record.rb
@@ -32,3 +32,6 @@ require 'rpush/client/active_record/adm/app'
 
 require 'rpush/client/active_record/pushy/notification'
 require 'rpush/client/active_record/pushy/app'
+
+require 'rpush/client/active_record/webpush/notification'
+require 'rpush/client/active_record/webpush/app'

--- a/lib/rpush/client/active_record/webpush/app.rb
+++ b/lib/rpush/client/active_record/webpush/app.rb
@@ -1,0 +1,11 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Webpush
+        class App < Rpush::Client::ActiveRecord::App
+          include Rpush::Client::ActiveModel::Webpush::App
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record/webpush/notification.rb
+++ b/lib/rpush/client/active_record/webpush/notification.rb
@@ -1,0 +1,12 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Webpush
+        class Notification < Rpush::Client::ActiveRecord::Notification
+          include Rpush::Client::ActiveModel::Webpush::Notification
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rpush/client/redis.rb
+++ b/lib/rpush/client/redis.rb
@@ -44,6 +44,9 @@ require 'rpush/client/redis/wns/badge_notification'
 require 'rpush/client/redis/pushy/app'
 require 'rpush/client/redis/pushy/notification'
 
+require 'rpush/client/redis/webpush/app'
+require 'rpush/client/redis/webpush/notification'
+
 Modis.configure do |config|
   config.namespace = :rpush
 end

--- a/lib/rpush/client/redis/webpush/app.rb
+++ b/lib/rpush/client/redis/webpush/app.rb
@@ -1,0 +1,15 @@
+module Rpush
+  module Client
+    module Redis
+      module Webpush
+        class App < Rpush::Client::Redis::App
+          include Rpush::Client::ActiveModel::Webpush::App
+
+          def vapid_keypair=(value)
+            self.certificate = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/redis/webpush/notification.rb
+++ b/lib/rpush/client/redis/webpush/notification.rb
@@ -1,0 +1,15 @@
+module Rpush
+  module Client
+    module Redis
+      module Webpush
+        class Notification < Rpush::Client::Redis::Notification
+          include Rpush::Client::ActiveModel::Webpush::Notification
+
+          def time_to_live=(value)
+            self.expiry = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -106,7 +106,7 @@ module Rpush
       client_module = Rpush::Client.const_get(client.to_s.camelize)
       Rpush.send(:include, client_module) unless Rpush.ancestors.include?(client_module)
 
-      [:Apns, :Gcm, :Wpns, :Wns, :Adm, :Pushy].each do |service|
+      [:Apns, :Gcm, :Wpns, :Wns, :Adm, :Pushy, :Webpush].each do |service|
         Rpush.const_set(service, client_module.const_get(service)) unless Rpush.const_defined?(service)
       end
 

--- a/lib/rpush/daemon.rb
+++ b/lib/rpush/daemon.rb
@@ -68,6 +68,9 @@ require 'rpush/daemon/adm'
 require 'rpush/daemon/pushy'
 require 'rpush/daemon/pushy/delivery'
 
+require 'rpush/daemon/webpush/delivery'
+require 'rpush/daemon/webpush'
+
 module Rpush
   module Daemon
     class << self

--- a/lib/rpush/daemon/webpush.rb
+++ b/lib/rpush/daemon/webpush.rb
@@ -1,0 +1,10 @@
+module Rpush
+  module Daemon
+    module Webpush
+      extend ServiceConfigMethods
+
+      dispatcher :http
+    end
+  end
+end
+

--- a/lib/rpush/daemon/webpush/delivery.rb
+++ b/lib/rpush/daemon/webpush/delivery.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "webpush"
+
+module Rpush
+  module Daemon
+    module Webpush
+
+      # Webpush::Request handles all the encryption / signing.
+      # We just override #perform to inject the http instance that is managed
+      # by Rpush.
+      #
+      class Request < ::Webpush::Request
+        def perform(http)
+          req = Net::HTTP::Post.new(uri.request_uri, headers)
+          req.body = body
+          http.request(uri, req)
+        end
+      end
+
+      class Delivery < Rpush::Daemon::Delivery
+
+        OK = [ 200, 201, 202 ].freeze
+        TEMPORARY_FAILURES = [ 429, 500, 502, 503, 504 ].freeze
+
+        def initialize(app, http, notification, batch)
+          @app = app
+          @http = http
+          @notification = notification
+          @batch = batch
+        end
+
+        def perform
+          response = send_request
+          process_response response
+        rescue SocketError, SystemCallError => error
+          mark_retryable(@notification, Time.now + 10.seconds, error)
+          raise
+        rescue StandardError => error
+          mark_failed(error)
+          raise
+        ensure
+          @batch.notification_processed
+        end
+
+        private
+
+        def send_request
+          # The initializer is inherited from Webpush::Request and looks like
+          # this:
+          #
+          # initialize(message: '', subscription:, vapid:, **options)
+          #
+          # where subscription is a hash of :endpoint and :keys, and vapid
+          # holds the vapid public and private keys and the :subject (which is
+          # an email address).
+          Request.new(
+            message: @notification.message,
+            subscription: @notification.subscription,
+            vapid: @app.vapid,
+            ttl: @notification.time_to_live,
+            urgency: @notification.urgency
+          ).perform(@http)
+        end
+
+        def process_response(response)
+          case response.code.to_i
+          when *OK
+            mark_delivered
+          when *TEMPORARY_FAILURES
+            retry_delivery(response)
+          else
+            fail_delivery(response)
+          end
+        end
+
+        def retry_delivery(response)
+          time = deliver_after_header(response)
+          if time
+            mark_retryable(@notification, time)
+          else
+            mark_retryable_exponential(@notification)
+          end
+          log_info("Webpush endpoint responded with a #{response.code} error. #{retry_message}")
+        end
+
+        def fail_delivery(response)
+          fail_message = fail_message(response)
+          log_error("#{@notification.id} failed: #{fail_message}")
+          fail Rpush::DeliveryError.new(response.code.to_i, @notification.id, fail_message)
+        end
+
+        def deliver_after_header(response)
+          Rpush::Daemon::RetryHeaderParser.parse(response.header['retry-after'])
+        end
+
+        def retry_message
+          deliver_after = @notification.deliver_after.strftime('%Y-%m-%d %H:%M:%S')
+          "Notification #{@notification.id} will be retried after #{deliver_after} (retry #{@notification.retries})."
+        end
+
+        def fail_message(response)
+          msg = Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i]
+          if explanation = response.body.to_s[0..200].presence
+            msg += ": #{explanation}"
+          end
+          msg
+        end
+
+      end
+    end
+  end
+end
+

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'rainbow'
+  s.add_runtime_dependency 'webpush', '~> 1.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.4.0'

--- a/spec/functional/webpush_spec.rb
+++ b/spec/functional/webpush_spec.rb
@@ -1,0 +1,30 @@
+require 'functional_spec_helper'
+
+describe 'Webpush' do
+  let(:code) { 201 }
+  let(:response) { instance_double('Net::HTTPResponse', code: code, body: '') }
+  let(:http) { instance_double('Net::HTTP::Persistent', request: response, shutdown: nil) }
+  let(:app) { Rpush::Webpush::App.create!(name: 'MyApp', vapid_keypair: VAPID_KEYPAIR) }
+
+  let(:device_reg) {
+    { endpoint: 'https://webpush-provider.example.org/push/some-id',
+      keys: {'auth' => 'DgN9EBia1o057BdhCOGURA', 'p256dh' => 'BAtxJ--7vHq9IVm8utUB3peJ4lpxRqk1rukCIkVJOomS83QkCnrQ4EyYQsSaCRgy_c8XPytgXxuyAvRJdnTPK4A'} }
+  }
+  let(:notification) { Rpush::Webpush::Notification.create!(app: app, registration_ids: [device_reg], data: { message: 'test' }) }
+
+  before do
+    allow(Net::HTTP::Persistent).to receive_messages(new: http)
+  end
+
+  it 'deliveres a notification successfully' do
+    expect { Rpush.push }.to change { notification.reload.delivered }.to(true)
+  end
+
+  context 'when delivery failed' do
+    let(:code) { 404 }
+    it 'marks a notification as failed' do
+      expect { Rpush.push }.to change { notification.reload.failed }.to(true)
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,8 @@ path = File.join(File.dirname(__FILE__), 'support')
 TEST_CERT = File.read(File.join(path, 'cert_without_password.pem'))
 TEST_CERT_WITH_PASSWORD = File.read(File.join(path, 'cert_with_password.pem'))
 
+VAPID_KEYPAIR = Webpush.generate_key.to_hash.merge(subject: 'rpush-test@example.org').to_json
+
 def after_example_cleanup
   Rpush.logger = nil
   Rpush::Daemon.store = nil

--- a/spec/unit/client/active_record/webpush/app_spec.rb
+++ b/spec/unit/client/active_record/webpush/app_spec.rb
@@ -1,0 +1,6 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::ActiveRecord::Webpush::App do
+  it_behaves_like 'Rpush::Client::Webpush::App'
+  it_behaves_like 'Rpush::Client::ActiveRecord::App'
+end if active_record?

--- a/spec/unit/client/active_record/webpush/notification_spec.rb
+++ b/spec/unit/client/active_record/webpush/notification_spec.rb
@@ -1,0 +1,6 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::ActiveRecord::Webpush::Notification do
+  it_behaves_like 'Rpush::Client::Webpush::Notification'
+  it_behaves_like 'Rpush::Client::ActiveRecord::Notification'
+end if active_record?

--- a/spec/unit/client/redis/webpush/app_spec.rb
+++ b/spec/unit/client/redis/webpush/app_spec.rb
@@ -1,0 +1,5 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::Redis::Webpush::App do
+  it_behaves_like 'Rpush::Client::Webpush::App'
+end if redis?

--- a/spec/unit/client/redis/webpush/notification_spec.rb
+++ b/spec/unit/client/redis/webpush/notification_spec.rb
@@ -1,0 +1,5 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::Redis::Webpush::Notification do
+  it_behaves_like 'Rpush::Client::Webpush::Notification'
+end if redis?

--- a/spec/unit/client/shared/webpush/app.rb
+++ b/spec/unit/client/shared/webpush/app.rb
@@ -1,0 +1,33 @@
+require 'unit_spec_helper'
+
+shared_examples 'Rpush::Client::Webpush::App' do
+  describe 'validates' do
+    subject { described_class.new }
+
+    it 'validates presence of name' do
+      is_expected.not_to be_valid
+      expect(subject.errors[:name]).to eq ["can't be blank"]
+    end
+
+    it 'validates presence of vapid_keypair' do
+      is_expected.not_to be_valid
+      expect(subject.errors[:vapid_keypair]).to eq ["can't be blank"]
+    end
+
+    it 'should require the vapid keypair to have subject, public and private key' do
+      subject.vapid_keypair = {}.to_json
+      is_expected.not_to be_valid
+      expect(subject.errors[:vapid_keypair].sort).to eq [
+        'must have a private_key entry',
+        'must have a public_key entry',
+        'must have a subject entry',
+      ]
+    end
+
+    it 'should require valid json for the keypair' do
+      subject.vapid_keypair = 'invalid'
+      is_expected.not_to be_valid
+      expect(subject.errors[:vapid_keypair].sort).to eq [ 'must be valid JSON' ]
+    end
+  end
+end

--- a/spec/unit/client/shared/webpush/notification.rb
+++ b/spec/unit/client/shared/webpush/notification.rb
@@ -1,0 +1,83 @@
+require 'unit_spec_helper'
+
+shared_examples 'Rpush::Client::Webpush::Notification' do
+  subject(:notification) { described_class.new }
+
+  describe 'notification attributes' do
+    describe 'data' do
+      subject { described_class.new(data: { message: 'test', urgency: 'normal' } ) }
+      it 'has a message' do
+        expect(subject.message).to eq "test"
+      end
+      it 'has an urgency' do
+        expect(subject.urgency).to eq "normal"
+      end
+    end
+
+    describe 'subscription' do
+      let(:subscription){ { endpoint: 'https://push.example.org/foo', keys: {'foo' => 'bar'}} }
+      subject { described_class.new(registration_ids: [subscription]) }
+
+      it "has a subscription" do
+        expect(subject.subscription).to eq({ endpoint: 'https://push.example.org/foo', keys: {foo: 'bar'} })
+      end
+    end
+  end
+
+
+  describe 'validates' do
+    let(:app) { Rpush::Webpush::App.create!(name: 'MyApp', vapid_keypair: VAPID_KEYPAIR) }
+
+    describe 'data' do
+      subject { described_class.new(app: app, registration_ids: [{endpoint: 'https://push.example.org/foo', keys: {'foo' => 'bar'}}]) }
+      it 'validates presence' do
+        is_expected.not_to be_valid
+        expect(subject.errors[:data]).to eq ["can't be blank"]
+      end
+
+      it "has a 'data' payload limit of 4096 bytes" do
+        subject.data = { message: 'a' * 4096 }
+        is_expected.not_to be_valid
+        expected_errors = ["Notification payload data cannot be larger than 4096 bytes."]
+        expect(subject.errors[:base]).to eq expected_errors
+      end
+    end
+
+    describe 'registration_ids' do
+      subject { described_class.new(app: app, data: { message: 'test' }) }
+      it 'validates presence' do
+        is_expected.not_to be_valid
+        expect(subject.errors[:registration_ids]).to eq ["can't be blank"]
+      end
+
+      it 'limits the number of registration ids to exactly 1' do
+        subject.registration_ids = [{endpoint: 'string', keys: { 'a' => 'hash' }}] * 2
+        is_expected.not_to be_valid
+        expected_errors = ["Number of registration_ids cannot be larger than 1."]
+        expect(subject.errors[:base]).to eq expected_errors
+      end
+
+      it 'validates the structure of the registration' do
+        subject.registration_ids = ['a']
+        is_expected.not_to be_valid
+        expect(subject.errors[:base]).to eq [
+          "Registration must have :endpoint (String) and :keys (Hash) keys"
+        ]
+
+        subject.registration_ids = [{endpoint: 'string', keys: { 'a' => 'hash' }}]
+        is_expected.to be_valid
+      end
+    end
+
+    describe 'time_to_live' do
+      subject { described_class.new(app: app, data: { message: 'test' }, registration_ids: [{endpoint: 'https://push.example.org/foo', keys: {'foo' => 'bar'}}]) }
+
+      it 'should be > 0' do
+        subject.time_to_live = -1
+        is_expected.not_to be_valid
+        expect(subject.errors[:time_to_live]).to eq ['must be greater than 0']
+      end
+    end
+
+  end
+end

--- a/spec/unit/daemon/webpush/delivery_spec.rb
+++ b/spec/unit/daemon/webpush/delivery_spec.rb
@@ -1,0 +1,142 @@
+require 'unit_spec_helper'
+
+describe Rpush::Daemon::Webpush::Delivery do
+  let(:app) { Rpush::Webpush::App.create!(name: 'MyApp', vapid_keypair: VAPID_KEYPAIR) }
+
+  # Push subscription information as received from a client browser when the
+  # user subscribed to push notifications.
+  let(:device_reg) {
+    { endpoint: 'https://webpush-provider.example.org/push/some-id',
+      keys: {'auth' => 'DgN9EBia1o057BdhCOGURA', 'p256dh' => 'BAtxJ--7vHq9IVm8utUB3peJ4lpxRqk1rukCIkVJOomS83QkCnrQ4EyYQsSaCRgy_c8XPytgXxuyAvRJdnTPK4A'} }
+  }
+
+  let(:data) { { message: 'some message' } }
+  let(:notification) { Rpush::Webpush::Notification.create!(app: app, registration_ids: [device_reg], data: data) }
+  let(:batch) { instance_double('Rpush::Daemon::Batch', notification_processed: nil) }
+  let(:response) { instance_double('Net::HTTPResponse', code: response_code, header: response_header, body: response_body) }
+  let(:response_code) { 201 }
+  let(:response_header) { {} }
+  let(:response_body) { nil }
+  let(:http) { instance_double('Net::HTTP::Persistent', request: response) }
+  let(:logger) { instance_double('Rpush::Logger', error: nil, info: nil, warn: nil, internal_logger: nil) }
+  let(:now) { Time.parse('2020-10-13 00:00:00 UTC') }
+
+  before do
+    allow(Rpush).to receive_messages(logger: logger)
+    allow(Time).to receive_messages(now: now)
+  end
+
+  subject(:delivery) { described_class.new(app, http, notification, batch) }
+
+  describe '#perform' do
+    shared_examples 'process notification' do
+      it 'invoke batch.notification_processed' do
+        subject.perform rescue nil
+        expect(batch).to have_received(:notification_processed)
+      end
+    end
+
+    context 'when response code is 201' do
+      before do
+        allow(batch).to receive(:mark_delivered)
+        Rpush::Daemon.store = Rpush::Daemon::Store.const_get(Rpush.config.client.to_s.camelcase).new
+      end
+
+      it 'marks the notification as delivered' do
+        delivery.perform
+        expect(batch).to have_received(:mark_delivered).with(notification)
+      end
+
+      it_behaves_like 'process notification'
+    end
+
+    shared_examples 'retry delivery' do |response_code:|
+      let(:response_code) { response_code }
+
+      shared_examples 'logs' do |deliver_after:|
+        let(:expected_log_message) do
+          "[MyApp] Webpush endpoint responded with a #{response_code} error. Notification #{notification.id} will be retried after #{deliver_after} (retry 1)."
+        end
+
+        it 'logs that the notification will be retried' do
+          delivery.perform
+          expect(logger).to have_received(:info).with(expected_log_message)
+        end
+      end
+
+      context 'when Retry-After header is present' do
+        let(:response_header) { { 'retry-after' => 10 } }
+
+        before do
+          allow(delivery).to receive(:mark_retryable) do
+            notification.deliver_after = now + 10.seconds
+            notification.retries += 1
+          end
+        end
+
+        it 'retry the notification' do
+          delivery.perform
+          expect(delivery).to have_received(:mark_retryable).with(notification, now + 10.seconds)
+        end
+
+        it_behaves_like 'logs', deliver_after: '2020-10-13 00:00:10'
+        it_behaves_like 'process notification'
+      end
+
+      context 'when Retry-After header is not present' do
+        before do
+          allow(delivery).to receive(:mark_retryable_exponential) do
+            notification.deliver_after = now + 2.seconds
+            notification.retries = 1
+          end
+        end
+
+        it 'retry the notification' do
+          delivery.perform
+          expect(delivery).to have_received(:mark_retryable_exponential).with(notification)
+        end
+
+        it_behaves_like 'logs', deliver_after: '2020-10-13 00:00:02'
+        it_behaves_like 'process notification'
+      end
+    end
+
+    it_behaves_like 'retry delivery', response_code: 429
+    it_behaves_like 'retry delivery', response_code: 500
+    it_behaves_like 'retry delivery', response_code: 502
+    it_behaves_like 'retry delivery', response_code: 503
+    it_behaves_like 'retry delivery', response_code: 504
+
+    context 'when delivery failed' do
+      let(:response_code) { 400 }
+      let(:fail_message) { 'that was a bad request' }
+      before do
+        allow(response).to receive(:body) { fail_message }
+        allow(batch).to receive(:mark_failed)
+      end
+
+      it 'marks the notification as failed' do
+        expect { delivery.perform }.to raise_error(Rpush::DeliveryError)
+        expected_message = "Unable to deliver notification #{notification.id}, " \
+                           "received error 400 (Bad Request: #{fail_message})"
+        expect(batch).to have_received(:mark_failed).with(notification, 400, expected_message)
+      end
+
+      it_behaves_like 'process notification'
+    end
+
+    context 'when SocketError raised' do
+      before do
+        allow(http).to receive(:request) { raise SocketError }
+        allow(delivery).to receive(:mark_retryable)
+      end
+
+      it 'retry delivery after 10 seconds' do
+        expect { delivery.perform }.to raise_error(SocketError)
+        expect(delivery).to have_received(:mark_retryable).with(notification, now + 10.seconds, SocketError)
+      end
+
+      it_behaves_like 'process notification'
+    end
+  end
+end


### PR DESCRIPTION
This PR implements Webpush support. Webpush is supported by all major desktop browsers except Safari, and has by now replaced the vendor specific Mozilla / Google Chrome desktop push solutions. All the heavy lifting is done by the [webpush gem](https://github.com/zaru/webpush), so the implementation is pretty straightforward.