### PR TITLE
Fix APNS2 documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ n.app = Rpush::Apns2::App.find_by_name("ios_app")
 n.device_token = "..." # hex string
 n.alert = "hi mom!"
 n.data = {
-  headers: { 'apns-topic': "BUNDLE ID", # the bundle id of the app, like com.example.appname
-  foo: :bar }
-  }
+  headers: { 'apns-topic': "BUNDLE ID", # the bundle id of the app, like com.example.appname },
+  foo: :bar
+}
 n.save!
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ n.app = Rpush::Apns2::App.find_by_name("ios_app")
 n.device_token = "..." # hex string
 n.alert = "hi mom!"
 n.data = {
-  headers: { 'apns-topic': "BUNDLE ID", # the bundle id of the app, like com.example.appname },
+  headers: { 'apns-topic': "BUNDLE ID" }, # the bundle id of the app, like com.example.appname
   foo: :bar
 }
 n.save!


### PR DESCRIPTION
Was in the middle of doing an upgrade from the APNS to the APNS2 implementation when I noticed this potential inaccuracy in the documentation. The fact that we were using APNS before this hinted to us that the documentation here for APNS2 was possibly incorrect, but people that intend to implement APNS2 right of the bat might face challenges based on this inaccuracy.