### PR TITLE
Feature/apns2 default headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ app.name = "ios_app"
 app.certificate = File.read("/path/to/sandbox.pem")
 app.environment = "development"
 app.password = "certificate password"
+app.bundle_id = "BUNDLE ID" # the unique bundle id of the app, like com.example.appname
 app.connections = 1
 app.save!
 ```
@@ -107,7 +108,7 @@ n.app = Rpush::Apns2::App.find_by_name("ios_app")
 n.device_token = "..." # hex string
 n.alert = "hi mom!"
 n.data = {
-  headers: { 'apns-topic': "BUNDLE ID" }, # the bundle id of the app, like com.example.appname
+  headers: { 'apns-topic': "BUNDLE ID" }, # the bundle id of the app, like com.example.appname. Not necessary if set on the app (see above)
   foo: :bar
 }
 n.save!

--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -107,7 +107,13 @@ module Rpush
         end
 
         def prepare_headers(notification)
-          notification_data(notification)[HTTP2_HEADERS_KEY] || {}
+          headers = {}
+
+          headers['apns-expiration'] = '0'
+          headers['apns-priority'] = '10'
+          headers['apns-topic'] = @app.bundle_id
+
+          headers.merge notification_data(notification)[HTTP2_HEADERS_KEY] || {}
         end
 
         def notification_data(notification)

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -42,6 +42,7 @@ describe 'APNs http2 adapter' do
     app.certificate = TEST_CERT
     app.name = 'test'
     app.environment = 'development'
+    app.bundle_id = 'com.example.app'
     app.save!
     app
   end
@@ -75,7 +76,12 @@ describe 'APNs http2 adapter' do
         :post,
         "/3/device/#{fake_device_token}",
         { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\",\"content-available\":1}}",
-          headers: {} }
+          headers: {
+            'apns-expiration' => '0',
+            'apns-priority' => '10',
+            'apns-topic' => 'com.example.app'
+          }
+        }
       )
       .and_return(fake_http2_request)
 
@@ -104,7 +110,11 @@ describe 'APNs http2 adapter' do
           "/3/device/#{fake_device_token}",
           { body: "{\"aps\":{\"alert\":\"test\",\"sound\":\"default\","\
                   "\"content-available\":1},\"some_field\":\"some value\"}",
-            headers: { 'apns-topic' => bundle_id }
+            headers: {
+              'apns-topic' => bundle_id,
+              'apns-expiration' => '0',
+              'apns-priority' => '10'
+            }
           }
         ).and_return(fake_http2_request)
 


### PR DESCRIPTION
This PR adds default `apns-*` headers to `Apns2::Delivery`, in the same way they are already implemented in `Apnsp8::Delivery`. Most notably, this makes use of the `bundle_id` stored with the application instead of having to set it as a header field on every notification.