### PR TITLE
Bug fix: APNS P8 Notifications Are Marked as Invalid When the Payload Exceeds 2kb (2048 bytes)

### DIFF
--- a/lib/rpush/client/active_record/apnsp8/notification.rb
+++ b/lib/rpush/client/active_record/apnsp8/notification.rb
@@ -3,6 +3,7 @@ module Rpush
     module ActiveRecord
       module Apnsp8
         class Notification < Rpush::Client::ActiveRecord::Apns::Notification
+          include Rpush::Client::ActiveModel::Apns2::Notification
         end
       end
     end

--- a/lib/rpush/client/redis/apnsp8/notification.rb
+++ b/lib/rpush/client/redis/apnsp8/notification.rb
@@ -3,6 +3,8 @@ module Rpush
     module Redis
       module Apnsp8
         class Notification < Rpush::Client::Redis::Notification
+          include Rpush::Client::ActiveModel::Apns::Notification
+          include Rpush::Client::ActiveModel::Apns2::Notification
           include Rpush::Client::ActiveModel::Apnsp8::Notification
         end
       end

--- a/spec/unit/client/active_record/apnsp8/notification_spec.rb
+++ b/spec/unit/client/active_record/apnsp8/notification_spec.rb
@@ -25,4 +25,4 @@ describe Rpush::Client::ActiveRecord::Apnsp8::Notification do
     expect(notification.valid?).to be_falsey
     expect(notification.errors[:base].include?("APN notification cannot be larger than 4096 bytes. Try condensing your alert and device attributes.")).to be_truthy
   end
-end
+end if active_record?

--- a/spec/unit/client/active_record/apnsp8/notification_spec.rb
+++ b/spec/unit/client/active_record/apnsp8/notification_spec.rb
@@ -1,0 +1,28 @@
+require "unit_spec_helper"
+
+describe Rpush::Client::ActiveRecord::Apnsp8::Notification do
+  subject(:notification) { described_class.new }
+
+  it_behaves_like 'Rpush::Client::Apns::Notification'
+  it_behaves_like 'Rpush::Client::ActiveRecord::Notification'
+
+  it "should validate the length of the binary conversion of the notification", :aggregate_failures do
+    notification = described_class.new
+    notification.app = Rpush::Apnsp8::App.create(apn_key: "1",
+                                                 apn_key_id: "2",
+                                                 name: 'test',
+                                                 environment: 'development',
+                                                 team_id: "3",
+                                                 bundle_id: "4")
+    notification.device_token = "a" * 108
+    notification.alert = ""
+
+    notification.alert << "a" until notification.payload.bytesize == 4096
+    expect(notification.valid?).to be_truthy
+    expect(notification.errors[:base]).to be_empty
+
+    notification.alert << "a"
+    expect(notification.valid?).to be_falsey
+    expect(notification.errors[:base].include?("APN notification cannot be larger than 4096 bytes. Try condensing your alert and device attributes.")).to be_truthy
+  end
+end

--- a/spec/unit/client/redis/apnsp8/notification_spec.rb
+++ b/spec/unit/client/redis/apnsp8/notification_spec.rb
@@ -26,4 +26,4 @@ describe Rpush::Client::Redis::Apnsp8::Notification do
     expect(notification.valid?).to be_falsey
     expect(notification.errors[:base].include?("APN notification cannot be larger than 4096 bytes. Try condensing your alert and device attributes.")).to be_truthy
   end
-end
+end if redis?

--- a/spec/unit/client/redis/apnsp8/notification_spec.rb
+++ b/spec/unit/client/redis/apnsp8/notification_spec.rb
@@ -1,6 +1,10 @@
 require "unit_spec_helper"
 
 describe Rpush::Client::Redis::Apnsp8::Notification do
+  after do
+    Rpush::Apnsp8::App.all.select { |a| a.environment == "development" && a.apn_key == "1" }.each(&:destroy)
+  end
+
   it_behaves_like "Rpush::Client::Apns::Notification"
 
   it "should validate the length of the binary conversion of the notification", :aggregate_failures do

--- a/spec/unit/client/redis/apnsp8/notification_spec.rb
+++ b/spec/unit/client/redis/apnsp8/notification_spec.rb
@@ -1,0 +1,25 @@
+require "unit_spec_helper"
+
+describe Rpush::Client::Redis::Apnsp8::Notification do
+  it_behaves_like "Rpush::Client::Apns::Notification"
+
+  it "should validate the length of the binary conversion of the notification", :aggregate_failures do
+    notification = described_class.new
+    notification.app = Rpush::Apnsp8::App.create(apn_key: "1",
+                                                 apn_key_id: "2",
+                                                 name: 'test',
+                                                 environment: 'development',
+                                                 team_id: "3",
+                                                 bundle_id: "4")
+    notification.device_token = "a" * 108
+    notification.alert = ""
+
+    notification.alert << "a" until notification.payload.bytesize == 4096
+    expect(notification.valid?).to be_truthy
+    expect(notification.errors[:base]).to be_empty
+
+    notification.alert << "a"
+    expect(notification.valid?).to be_falsey
+    expect(notification.errors[:base].include?("APN notification cannot be larger than 4096 bytes. Try condensing your alert and device attributes.")).to be_truthy
+  end
+end


### PR DESCRIPTION
Rpush marks APNS P8 notifications as being invalid, when the notification payload byte size exceeds 2kb. Since the notifications are marked as invalid, they aren't delivered to APNS. APNS, however, allows a maximum payload byte size of [4kb on notifications delivered via http/2](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html).

This PR makes the following changes to resolve the issue:

1. Adds relevant tests to `Rpush::Client::ActiveRecord::Apnsp8::Notification` and `Rpush::Client::Redis::Apnsp8::Notification`. 
2. These tests fail prior to the changes on this PR, and pass with the changes on this PR.

This PR is closely related to https://github.com/rpush/rpush/issues/545 and https://github.com/rpush/rpush/pull/561, where a similar change was made to APNS and APNS2 notifications.
