### PR TITLE
Fix silent APNS notifications for Apns2 and Apnsp8

### DIFF
--- a/lib/rpush/client/active_model/apns/notification.rb
+++ b/lib/rpush/client/active_model/apns/notification.rb
@@ -52,6 +52,10 @@ module Rpush
             self.data = (data || {}).merge(CONTENT_AVAILABLE_KEY => true)
           end
 
+          def content_available?
+            (self.data || {})[CONTENT_AVAILABLE_KEY]
+          end
+
           def as_json(options = nil) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
             json = ActiveSupport::OrderedHash.new
 

--- a/lib/rpush/daemon/apns2/delivery.rb
+++ b/lib/rpush/daemon/apns2/delivery.rb
@@ -112,6 +112,7 @@ module Rpush
           headers['apns-expiration'] = '0'
           headers['apns-priority'] = '10'
           headers['apns-topic'] = @app.bundle_id
+          headers['apns-push-type'] = 'background' if notification.content_available?
 
           headers.merge notification_data(notification)[HTTP2_HEADERS_KEY] || {}
         end

--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -144,6 +144,7 @@ module Rpush
           headers['apns-priority'] = '10'
           headers['apns-topic'] = @app.bundle_id
           headers['authorization'] = "bearer #{jwt_token}"
+          headers['apns-push-type'] = 'background' if notification.content_available?
 
           headers.merge notification_data(notification)[HTTP2_HEADERS_KEY] || {}
         end

--- a/spec/functional/apns2_spec.rb
+++ b/spec/functional/apns2_spec.rb
@@ -79,7 +79,8 @@ describe 'APNs http2 adapter' do
           headers: {
             'apns-expiration' => '0',
             'apns-priority' => '10',
-            'apns-topic' => 'com.example.app'
+            'apns-topic' => 'com.example.app',
+            'apns-push-type' => 'background'
           }
         }
       )
@@ -113,7 +114,8 @@ describe 'APNs http2 adapter' do
             headers: {
               'apns-topic' => bundle_id,
               'apns-expiration' => '0',
-              'apns-priority' => '10'
+              'apns-priority' => '10',
+              'apns-push-type' => 'background'
             }
           }
         ).and_return(fake_http2_request)

--- a/spec/unit/client/shared/apns/notification.rb
+++ b/spec/unit/client/shared/apns/notification.rb
@@ -165,6 +165,21 @@ shared_examples 'Rpush::Client::Apns::Notification' do
     end
   end
 
+  describe 'content_available?' do
+    context 'if not set' do
+      it 'should be false' do
+        expect(notification.content_available?).to be_falsey
+      end
+    end
+
+    context 'if set' do
+      it 'should be true' do
+        notification.content_available = true
+        expect(notification.content_available?).to be_truthy
+      end
+    end
+  end
+
   describe 'url-args' do
     it 'includes url-args in the payload' do
       notification.url_args = ['url-arg-1']


### PR DESCRIPTION
In this PR `apns-push-type` header was added for silent notifications.
According to documentation: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app#2980040 about background notifications `APNs server requires the apns-push-type field when sending push notifications to Apple Watch, and recommends it for all platforms`. Also from documentation about POST APNS requests: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947607 `apns-push-type` header required for watchOS 6 and later; recommended for macOS, iOS, tvOS, and iPadOS.

Legacy `Rpush::Apns::Notification` works fine without this header but it will be removed 31 March. I updated our code to `Rpush::Apnsp8::Notification` and also tested `Rpush::Apns2::Notification` and background notifications did not work. I checked APNS documentation, added this fix and now it works great.