### PR TITLE
Bump gemspec post_install_message

### DIFF
--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   s.post_install_message = <<~POST_INSTALL_MESSAGE
-    When upgrading, don't forget to run `bundle exec rpush init` to get all the latest migrations.
+    When upgrading Rpush, don't forget to run `bundle exec rpush init` to get all the latest migrations.
 
     For details on this specific release, refer to the CHANGELOG.md file.
     https://github.com/rpush/rpush/blob/master/CHANGELOG.md


### PR DESCRIPTION
Hi, this is a tiny suggestion for a clarification to the gemspec post_install_message.

We are starting to use Rpush but are trying out the Redis approach instead of DB. This might be useful since we've received questions from other contributors (they were not involved in the Rpush implementation) after upgrading an unrelated gem.

In our case we don't want anyone to add the migrations and this change just makes it a bit clearer in the wording that running the command isn't necessary, though mostly for Rpush unrelated work where they might or might not be familiar with Rpush.

I appreciate the gem and the work behind maintaining it regardless of this gets merged or not, cheers 👍 