### PR TITLE
Eliminate deprecation warning in Ruby 3.0

### DIFF
--- a/lib/rpush/daemon/string_helpers.rb
+++ b/lib/rpush/daemon/string_helpers.rb
@@ -2,7 +2,7 @@ module Rpush
   module Daemon
     module StringHelpers
       def pluralize(count, singular, plural = nil)
-        if count == 1 || count =~ /^1(\.0+)?$/
+        if count == 1
           word = singular
         else
           word = plural || singular.pluralize


### PR DESCRIPTION
When Object#=~ is called on an Integer in Ruby 3.0, it always returns nil. It appears that #pluralize is only being used with Numeric values, so `count == 1` should be a sufficient check.