### PR TITLE
Fixed infinite loop issue with Apnsp8 delivery

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -86,6 +86,10 @@ module Rpush
         def remote_max_concurrent_streams
           # 0x7fffffff is the default value from http-2 gem (2^31)
           if @client.remote_settings[:settings_max_concurrent_streams] == 0x7fffffff
+            # Ideally we'd fall back to `#local_settings` here, but `NetHttp2::Client`
+            # doesn't expose that attr from the `HTTP2::Client` it wraps. Instead, we
+            # chose a hard-coded value matching the default local setting from the
+            # `HTTP2::Client` class
             DEFAULT_MAX_CONCURRENT_STREAMS
           else
             @client.remote_settings[:settings_max_concurrent_streams]

--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -8,6 +8,7 @@ module Rpush
       class Delivery < Rpush::Daemon::Delivery
         RETRYABLE_CODES = [ 429, 500, 503 ]
         CLIENT_JOIN_TIMEOUT = 60
+        DEFAULT_MAX_CONCURRENT_STREAMS = 100
 
         def initialize(app, http2_client, token_provider, batch)
           @app = app
@@ -85,7 +86,7 @@ module Rpush
         def remote_max_concurrent_streams
           # 0x7fffffff is the default value from http-2 gem (2^31)
           if @client.remote_settings[:settings_max_concurrent_streams] == 0x7fffffff
-            0
+            DEFAULT_MAX_CONCURRENT_STREAMS
           else
             @client.remote_settings[:settings_max_concurrent_streams]
           end

--- a/spec/unit/daemon/apnsp8/delivery_spec.rb
+++ b/spec/unit/daemon/apnsp8/delivery_spec.rb
@@ -1,0 +1,53 @@
+require 'unit_spec_helper'
+
+describe Rpush::Daemon::Apnsp8::Delivery do
+  subject(:delivery) { described_class.new(app, http2_client, token_provider, batch) }
+
+  let(:app) { double(bundle_id: 'MY BUNDLE ID') }
+  let(:notification1) { double('Notification 1', data: {}, as_json: {}).as_null_object }
+  let(:notification2) { double('Notification 2', data: {}, as_json: {}).as_null_object }
+
+  let(:token_provider) { double(token: 'MY JWT TOKEN') }
+  let(:max_concurrent_streams) { 100 }
+  let(:remote_settings) { { settings_max_concurrent_streams: max_concurrent_streams } }
+  let(:http_request) { double(on: nil) }
+  let(:http2_client) do
+    double(
+      stream_count: 0,
+      call_async: nil,
+      join: nil,
+      prepare_request: http_request,
+      remote_settings: remote_settings
+    )
+  end
+
+  let(:batch) { double(mark_delivered: nil, all_processed: nil) }
+  let(:logger) { double(info: nil) }
+
+  before do
+    allow(batch).to receive(:each_notification) do |&blk|
+      [notification1, notification2].each(&blk)
+    end
+    allow(Rpush).to receive_messages(logger: logger)
+  end
+
+  describe '#perform' do
+    context 'with an HTTP2 client where max concurrent streams is not set' do
+      let(:max_concurrent_streams) { 0x7fffffff }
+
+      it 'does not fall into an infinite loop on notifications after the first' do
+        start = Time.now
+        thread = Thread.new { delivery.perform }
+
+        loop do
+          break unless thread.alive?
+
+          if Time.now - start > 0.5
+            thread.kill
+            fail 'Stuck in an infinite loop'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #606 

With Apnsp8 delivery, the second notification in a batch was always caught in an infinite loop, leaving it and all subsequent notification stuck in "processing"