### PR TITLE
Adds Rails 7 Support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -32,9 +32,9 @@ appraise "rails-6.1" do
 end
 
 appraise "rails-7.0" do
-  gem "activesupport", "~> 7.0.0.alpha2"
+  gem "activesupport", "~> 7.0.0.rc1"
 
   group :development do
-    gem "rails", "~> 7.0.0.alpha2"
+    gem "rails", "~> 7.0.0.rc1"
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -32,9 +32,9 @@ appraise "rails-6.1" do
 end
 
 appraise "rails-7.0" do
-  gem "activesupport", "~> 7.0.0.rc1"
+  gem "activesupport", "~> 7.0.0.rc3"
 
   group :development do
-    gem "rails", "~> 7.0.0.rc1"
+    gem "rails", "~> 7.0.0.rc3"
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -32,9 +32,9 @@ appraise "rails-6.1" do
 end
 
 appraise "rails-7.0" do
-  gem "activesupport", "~> 7.0.0.rc3"
+  gem "activesupport", "~> 7.0.0"
 
   group :development do
-    gem "rails", "~> 7.0.0.rc3"
+    gem "rails", "~> 7.0.0"
   end
 end

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activesupport", "~> 7.0.0.alpha2"
+gem "activesupport", "~> 7.0.0.rc1"
 
 group :development do
-  gem "rails", "~> 7.0.0.alpha2"
+  gem "rails", "~> 7.0.0.rc1"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activesupport", "~> 7.0.0.rc1"
+gem "activesupport", "~> 7.0.0.rc3"
 
 group :development do
-  gem "rails", "~> 7.0.0.rc1"
+  gem "rails", "~> 7.0.0.rc3"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activesupport", "~> 7.0.0.rc3"
+gem "activesupport", "~> 7.0.0"
 
 group :development do
-  gem "rails", "~> 7.0.0.rc3"
+  gem "rails", "~> 7.0.0"
 end
 
 gemspec path: "../"

--- a/lib/generators/templates/rpush_2_0_0_updates.rb
+++ b/lib/generators/templates/rpush_2_0_0_updates.rb
@@ -58,7 +58,11 @@ class Rpush200Updates < ActiveRecord::Migration[5.0]
 
   def self.adapter_name
     env = (defined?(Rails) && Rails.env) ? Rails.env : 'development'
-    Hash[ActiveRecord::Base.configurations[env].map { |k,v| [k.to_sym,v] }][:adapter]
+    if ActiveRecord::VERSION::MAJOR > 6
+      ActiveRecord::Base.configurations.configs_for(env_name: env).first.configuration_hash[:adapter]
+    else
+      Hash[ActiveRecord::Base.configurations[env].map { |k,v| [k.to_sym,v] }][:adapter]
+    end
   end
 
   def self.postgresql?

--- a/spec/unit/daemon/store/active_record_spec.rb
+++ b/spec/unit/daemon/store/active_record_spec.rb
@@ -66,4 +66,11 @@ describe Rpush::Daemon::Store::ActiveRecord do
       expect(store.deliverable_notifications(Rpush.config.batch_size)).to be_empty
     end
   end
+
+  describe "#adapter_name" do
+    it "should return the adapter name" do
+      adapter = ENV["ADAPTER"] || "postgresql"
+      expect(store.adapter_name).to eq(adapter)
+    end
+  end
 end if active_record?


### PR DESCRIPTION
This PR adds support for rpush on Rails 7.

A `NoMethodError` currently happens when running `rpush init` on a new Rails 7 app. Steps to recreate the exception manually are included on the commit message for dd6eeb5.

The exception happens because `ActiveRecord::Base.configurations.to_h` [was removed](https://github.com/rails/rails/commit/190f006e78fcf2d5f4e4565f2d25b12545f12dde) in Rails version v7.0.0.rc1, in favor of `ActiveRecord::Base.configurations.configs_for`. 

This PR updates rpush to use `ActiveRecord::Base.configurations.configs_for`, if `ActiveRecord` is greater than version 6. On older versions of Rails, however, `ActiveRecord::Base.configurations.configs_for` [returns a `NoMethodError`](https://gist.github.com/gregblake/b68f32a8a27c13f836690bfa4afb7803). Therefore, the change has been made in a backwards compatible manner, by falling back to ` Hash[ActiveRecord::Base.configurations]` on older versions of Rails. This change was made on dd6eeb5088b4846e828e6df7cf6e28997356dba3 and e6ec52174d4ade21b577d3e04aa670b0a09557ae. The commit message on dd6eeb5088b4846e828e6df7cf6e28997356dba3 provides additional context on these changes.