### PR TITLE
Fix deprecation warnings from the redis gem

### DIFF
--- a/lib/rpush/daemon/store/redis.rb
+++ b/lib/rpush/daemon/store/redis.rb
@@ -152,10 +152,10 @@ module Rpush
           retryable_ns = Rpush::Client::Redis::Notification.absolute_retryable_namespace
 
           Modis.with_connection do |redis|
-            retryable_results = redis.multi do
+            retryable_results = redis.multi do |transaction|
               now = Time.now.to_i
-              redis.zrangebyscore(retryable_ns, 0, now)
-              redis.zremrangebyscore(retryable_ns, 0, now)
+              transaction.zrangebyscore(retryable_ns, 0, now)
+              transaction.zremrangebyscore(retryable_ns, 0, now)
             end
 
             retryable_results.first
@@ -167,9 +167,9 @@ module Rpush
           pending_ns = Rpush::Client::Redis::Notification.absolute_pending_namespace
 
           Modis.with_connection do |redis|
-            pending_results = redis.multi do
-              redis.zrange(pending_ns, 0, limit)
-              redis.zremrangebyrank(pending_ns, 0, limit)
+            pending_results = redis.multi do |transaction|
+              transaction.zrange(pending_ns, 0, limit)
+              transaction.zremrangebyrank(pending_ns, 0, limit)
             end
 
             pending_results.first


### PR DESCRIPTION
Fixes these warnings introduced in [Redis 4.6.0](https://github.com/redis/redis-rb/blob/21ec1dec064f43def1f47983431861e6491b770e/CHANGELOG.md#460)

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end

(called from /bundle_path/ruby/3.0.0/gems/rpush-7.0.0/lib/rpush/daemon/store/redis.rb:170:in `block in pending_notification_ids'}
```

Similar commit in sidekiq: https://github.com/mperham/sidekiq/commit/c792342753e24e6471b6e7ab79de09814c1d5573
