### PR TITLE
Update embedding section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,8 @@ else
 end
 ```
 
-Call this during startup of your application, for example, by adding it to the end of `config/rpush.rb`. See [Embedding API](https://github.com/rpush/rpush/wiki/Embedding-API) for more details.
+Call this during startup of your application, for example, by adding it to the `config.ru` file.
+See [Embedding API](https://github.com/rpush/rpush/wiki/Embedding-API) for more details.
 
 #### Using mina
 


### PR DESCRIPTION
Lets change the file suggested for embedding code from `config/rpush.rb` to `config.ru`, because embedding command placed in config file (or Rails initializer) will run in Rake tasks, Rails console and Sidekiq process too, but we dan't want that!

Also I added the similar instruction to the "[Embedding API](https://github.com/rpush/rpush/wiki/Embedding-API)" Wiki page.