### PR TITLE
Migrate "webpush" to the new "web-push" fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ according to the spec, can be used by push service providers to contact you in
 case of problems) in the `certificates` field of the Rpush Application record:
 
 ```ruby
-vapid_keypair = Webpush.generate_key.to_hash
+vapid_keypair = WebPush.generate_key.to_hash
 app = Rpush::Webpush::App.new
 app.name = 'webpush'
 app.certificate = vapid_keypair.merge(subject: 'user@example.org').to_json

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'rainbow'
-  s.add_runtime_dependency 'webpush', '~> 1.0'
+  s.add_runtime_dependency 'web-push', '~> 3.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.4.0'


### PR DESCRIPTION
Webpush is no longer supported (https://github.com/zaru/webpush/issues/107).
And the new [pushpad/web-push](https://github.com/pushpad/web-push) gem has support for OpenSSL 3.