### PR TITLE
Make the name field to be nullable

### DIFF
--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -53,6 +53,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_4_1_0_updates')
     add_rpush_migration('rpush_4_1_1_updates')
     add_rpush_migration('rpush_4_2_0_updates')
+    add_rpush_migration('rpush_7_0_1_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_7_0_1_updates.rb
+++ b/lib/generators/templates/rpush_7_0_1_updates.rb
@@ -1,0 +1,9 @@
+class Rpush701Updates < ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  def self.up
+    change_column_null :rpush_apps, :name, false
+  end
+
+  def self.down
+    change_column_null :rpush_apps, :name, true
+  end
+end

--- a/lib/rpush/client/active_record/app.rb
+++ b/lib/rpush/client/active_record/app.rb
@@ -5,8 +5,6 @@ module Rpush
         self.table_name = 'rpush_apps'
 
         has_many :notifications, class_name: 'Rpush::Client::ActiveRecord::Notification', dependent: :destroy
-
-        validates :name, presence: true, uniqueness: { scope: [:type, :environment], case_sensitive: true }
       end
     end
   end

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -43,6 +43,7 @@ require 'generators/templates/rpush_3_3_1_updates'
 require 'generators/templates/rpush_4_1_0_updates'
 require 'generators/templates/rpush_4_1_1_updates'
 require 'generators/templates/rpush_4_2_0_updates'
+require 'generators/templates/rpush_7_0_1_updates'
 
 migrations = [
   AddRpush,
@@ -60,7 +61,8 @@ migrations = [
   Rpush331Updates,
   Rpush410Updates,
   Rpush411Updates,
-  Rpush420Updates
+  Rpush420Updates,
+  Rpush701Updates
 ]
 
 unless ENV['CI']


### PR DESCRIPTION
## What happened

Allow the `rpush_apps` name field to be nullable

## Insight

- Remove the validations
- Remove the null constrain in the database migration

## Proof Of Work







