### PR TITLE
test: adjust the expected Modis option format to match the new spec

### DIFF
--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -41,6 +41,6 @@ describe Rpush::Configuration do
   it 'delegate redis_options to Modis' do
     Rpush.config.client = :redis
     Rpush.config.redis_options = { hi: :mom }
-    expect(Modis.redis_options).to eq(hi: :mom)
+    expect(Modis.redis_options).to eq({ default: { hi: :mom } })
   end
 end


### PR DESCRIPTION
The format of Rpush.config.redis_options changed.

before:
```ruby
{:url=>"redis://redis_3_test", :db=>7}
```
after:
```ruby
{:default=>{:url=>"redis://redis_3_test", :db=>7}}
```