### PR TITLE
feat: fcm add iOS badge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Merged pull requests:**
 
+* Add support for FSM iOS badges [\#704](https://github.com/rpush/rpush/pull/704) ([WoutDev](https://github.com/WoutDev))
+
 [Full Changelog](https://github.com/rpush/rpush/compare/v9.0.0...HEAD)
 
 ## [v9.0.0](https://github.com/rpush/rpush/tree/v9.0.0) (2024-09-09)

--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -77,6 +77,7 @@ module Rpush
             aps['mutable-content'] = 1 if mutable_content
             aps['content-available'] = 1 if content_available
             aps['sound'] = 'default' if sound == 'default'
+            aps['badge'] = badge if badge
 
             json['payload']['aps'] = aps
 

--- a/spec/unit/client/shared/fcm/notification.rb
+++ b/spec/unit/client/shared/fcm/notification.rb
@@ -84,7 +84,7 @@ shared_examples 'Rpush::Client::Fcm::Notification' do
 
   it 'includes the badge if defined' do
     notification.badge = 3
-    expect(notification.as_json['payload']['aps']['badge']).to eq(3)
+    expect(notification.as_json['message']['apns']['payload']['aps']['badge']).to eq(3)
   end
 
   it 'excludes the notification payload if undefined' do

--- a/spec/unit/client/shared/fcm/notification.rb
+++ b/spec/unit/client/shared/fcm/notification.rb
@@ -26,7 +26,7 @@ shared_examples 'Rpush::Client::Fcm::Notification' do
     expect(notification.as_json['message']['notification']).to eq({"title"=>"title", "body"=>"body"})
   end
 
-  it "moves notification keys to the correcdt location" do
+  it "moves notification keys to the correct location" do
     notification.app = app
     notification.device_token = "valid"
     notification.notification = { "title" => "valid", "body" => "valid", "color" => "valid for android" }
@@ -80,6 +80,11 @@ shared_examples 'Rpush::Client::Fcm::Notification' do
   it 'includes the notification payload if defined' do
     notification.notification = { key: 'any key is allowed' }
     expect(notification.as_json['message']).to have_key 'notification'
+  end
+
+  it 'includes the badge if defined' do
+    notification.badge = 3
+    expect(notification.as_json['payload']['aps']['badge']).to eq(3)
   end
 
   it 'excludes the notification payload if undefined' do


### PR DESCRIPTION
Closes #703 

### Background on the change
FSM messages should be consistent with: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Message

These messages support a "apns" key: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#ApnsConfig

Which in its turn has a "payload" key, described as:
> APNs payload as a JSON object, including both aps dictionary and custom payload. See [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification). If present, it overrides [google.firebase.fcm.v1.Notification.title](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Notification.FIELDS.title) and [google.firebase.fcm.v1.Notification.body](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Notification.FIELDS.body).

The Payload Key Reference contains information on supported keys, including a "badge":
> The number to display in a badge on your app’s icon. Specify 0 to remove the current badge, if any.


