### PR TITLE
IOS Notification Key

### DIFF
--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -13,6 +13,9 @@ module Rpush
                                          default_vibrate_timings default_light_settings vibrate_timings
                                          visibility notification_count light_settings].freeze
 
+          IOS_NOTIFICATION_KEYS = %w[title subtitle body launch-image title-loc-key title-loc-args
+                                      subtitle-loc-key subtitle-loc-args loc-key loc-args].freeze
+
           def self.included(base)
             base.instance_eval do
               validates :device_token, presence: true
@@ -78,6 +81,7 @@ module Rpush
             aps['content-available'] = 1 if content_available
             aps['sound'] = 'default' if sound == 'default'
             aps['badge'] = badge if badge
+            aps['alert'] = ios_notification if notification
 
             json['payload']['aps'] = aps
 
@@ -101,6 +105,12 @@ module Rpush
             json['sound'] = sound if sound
             json['default_sound'] = sound == 'default' ? true : false
             json
+          end
+
+          def ios_notification
+            return {} unless notification
+
+            notification.slice(*IOS_NOTIFICATION_KEYS)
           end
 
           def priority_str

--- a/lib/rpush/client/active_model/fcm/notification_keys_in_allowed_list_validator.rb
+++ b/lib/rpush/client/active_model/fcm/notification_keys_in_allowed_list_validator.rb
@@ -6,7 +6,7 @@ module Rpush
           def validate(record)
             return unless record.notification
 
-            allowed_keys = Notification::ROOT_NOTIFICATION_KEYS + Notification::ANDROID_NOTIFICATION_KEYS
+            allowed_keys = Notification::ROOT_NOTIFICATION_KEYS + Notification::ANDROID_NOTIFICATION_KEYS + Notification::IOS_NOTIFICATION_KEYS
             invalid_keys = record.notification.keys - allowed_keys
 
             return if invalid_keys.empty?


### PR DESCRIPTION
I have added all the keys for the alert payload inside APNS for the FCM Notification

https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification

It was possible to send loc key for android but not for IOS.
