### PR TITLE
Update FCM steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The app `environment` for any Apns* option is "development" for XCode installs, 
 #### Firebase Cloud Messaging
 
 You will need two params to make use of FCM via Rpush.
-- `firebase_project_id` - The `Project ID` in your Firebase Project Settings
+- `firebase_project_id` - The `Project number` in your Firebase Project Settings
 - `json_key` - The JSON key file for a service account with the `Firebase Admin SDK Administrator Service Agent` role.
 
 Create service account in the google cloud account attached to your firebase account:
@@ -151,6 +151,7 @@ fcm_app.save!
 n = Rpush::Fcm::Notification.new
 n.app = Rpush::Fcm::App.where(name: "fcm_app").first
 n.device_token = device_token # Note that device_token is used here instead of registration_ids
+n.notification = { title: "push title", body: "hi mom!" } # either title or body needs to be set, or nothing goes through
 n.data = {}.transform_values(&:to_s) # All values going in here have to be strings, if you have anything else - nothing goes through
 n.save!
 ```


### PR DESCRIPTION
Had some struggles setting up FCM in my repository with the given documentation, so I'm suggesting some extra steps people might look over on their initial tests. From the documentation it's not immediately clear that `data` is not where the title and body of a notification go. Leaving `notification` blank causes rpush to return a success, but nothing will actually arrive on the device. The project ID also might have changed labels overtime, as setting the "project ID" as my `firebase_project_id` instead of the "project number" also prevents notifications from showing up.