### PR TITLE
Stop running Rubocop in CI for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,9 +87,6 @@ jobs:
         POSTGRES_PORT: 5432
         CLIENT: ${{ matrix.client }}
 
-    - name: Run rubocop
-      run: bundle exec rubocop
-
   tests:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Pending https://github.com/rpush/rpush/pull/713. Necessary to avoid blocking critical work like https://github.com/rpush/rpush/pull/706.