### PR TITLE
Fix APNs P8 HTTP2 error recovery

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -25,6 +25,8 @@ module Rpush
 
           # Send all preprocessed requests at once
           @client.join(timeout: CLIENT_JOIN_TIMEOUT)
+          error = @client.check_for_error
+          raise error if error
         rescue NetHttp2::AsyncRequestTimeout => error
           mark_batch_retryable(Time.now + 10.seconds, error)
           @client.close

--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -31,7 +31,11 @@ module Rpush
           mark_batch_retryable(Time.now + 10.seconds, error)
           @client.close
           raise
-        rescue Errno::ECONNREFUSED, SocketError, HTTP2::Error::StreamLimitExceeded => error
+        rescue OpenSSL::SSL::SSLError,
+               Errno::ECONNRESET,
+               Errno::ECONNREFUSED,
+               SocketError,
+               HTTP2::Error::StreamLimitExceeded => error
           # TODO restart connection when StreamLimitExceeded
           mark_batch_retryable(Time.now + 10.seconds, error)
           raise

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -34,10 +34,32 @@ module Rpush
         def create_http2_client(app)
           url = URLS[app.environment.to_sym]
           client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_TIMEOUT)
+
+          client.instance_eval do
+            @error_mutex = Mutex.new
+            @error = nil
+
+            def record_error(error)
+              @error_mutex.synchronize { @error = error }
+            end
+
+            def check_for_error
+              @error_mutex.synchronize do
+                return unless @error
+
+                error = @error.dup
+                @error = nil
+                error
+              end
+            end
+          end
+
           client.on(:error) do |error|
+            client.record_error(error)
             log_error(error)
             reflect(:error, error)
           end
+
           client
         end
       end


### PR DESCRIPTION
Currently RPush uses faulty logic when determining if a notification should be retried.  It only recognizes certain responses from APNs as needing a retry.  Which means that any failure to actually deliver the notification will result in the notification being marked as failed.

Clearly, we should retry the notification unless - and until - we receive a response from APNs with a permanent failure code, or the notification reaches its maximum number of retries.

It is very common to receive `Errno::ECONNRESET: Connection reset by peer` errors from the APNs connection, and this issue has not been resolved in RPush.  See https://github.com/rpush/rpush/issues/607.  This error occurs because Apple closes the connection on their end after some period of inactivity.  It's also common to receive `OpenSSL::SSL::SSLError` errors from the HTTP2 socket.

When an error occurs in the `NetHttp2` client, it calls the error callback registered in `create_http2_client` and swallows the error.  This means that the `Delivery` class never sees it and cannot handle it.  So the notification remains in the processing state indefinitely. The threads which `NetHttp2` create have `abort_on_exception` set to `true`, so we cannot
raise the error there otherwise it will immediately terminate the whole process.  So we store it on the client and check for it after the `join` call.  If we see an error then we raise it in the `perform` method so that it can be handled appropriately by either retrying the notification or marking it as failed.