### PR TITLE
doc(webpush): Correct webpush JWT subject format

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ case of problems) in the `certificates` field of the Rpush Application record:
 vapid_keypair = Webpush.generate_key.to_hash
 app = Rpush::Webpush::App.new
 app.name = 'webpush'
-app.certificate = vapid_keypair.merge(subject: 'user@example.org').to_json
+app.certificate = vapid_keypair.merge(subject: 'mailto:user@example.org').to_json
 app.connections = 1
 app.save!
 ```


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-webpush-vapid-01#section-2.1

> If the application server wishes to provide contact details it MAY
   include an "sub" (Subject) claim in the JWT.  The "sub" claim SHOULD
   include a contact URI for the application server as either a
   "mailto:" (email) [[RFC6068](https://datatracker.ietf.org/doc/html/rfc6068)] or an "https:" [[RFC2818](https://datatracker.ietf.org/doc/html/rfc2818)] URI.