### PR TITLE
Fix active record logger dependency for older rails versions that was breaking the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/rpush/rpush/tree/HEAD)
 
+* Fix active record logger dependency for older rails versions that was breaking the build [\#731](https://github.com/rpush/rpush/pull/731) ([SixiS](https://github.com/sixis))
+
 [Full Changelog](https://github.com/rpush/rpush/compare/v9.2.0...HEAD)
 
 ## [v9.2.0](https://github.com/rpush/rpush/tree/v9.2.0) (2024-11-28)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 6.0, != 7.2.1, != 7.2.0, != 7.1.4)
       googleauth
       jwt (>= 1.5.6)
+      logger
       multi_json (~> 1.0)
       net-http-persistent
       net-http2 (~> 0.18, >= 0.18.3)
@@ -41,7 +42,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    appraisal (2.4.1)
+    appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -217,7 +218,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    uri (1.0.2)
+    uri (1.0.3)
     web-push (3.0.1)
       jwt (~> 2.0)
       openssl (~> 3.0)

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-http2', '~> 0.18', '>= 0.18.3'
   s.add_runtime_dependency 'jwt', '>= 1.5.6'
   s.add_runtime_dependency 'activesupport', '>= 6.0', '!= 7.1.4', '!= 7.2.0', '!= 7.2.1' # https://github.com/rails/rails/issues/52820
+  s.add_runtime_dependency 'logger'
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'rainbow'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ def redis?
 end
 
 if active_record?
+  require 'logger'
   require 'active_record'
   if ActiveRecord::Base.respond_to?(:default_column_serializer)
     # New default in Rails 7.1: https://github.com/rails/rails/pull/47422


### PR DESCRIPTION
Can read more on the active record logger issue:
https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
Also a good idea to add the logger gem as a dependancy as it will stop being a core Ruby library in 3.5.

Also bumped the appraisal gem to fix:
https://github.com/thoughtbot/appraisal/issues/199