### PR TITLE
docs: Correct WebPush key generation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ according to the spec, can be used by push service providers to contact you in
 case of problems) in the `certificates` field of the Rpush Application record:
 
 ```ruby
-vapid_keypair = Webpush.generate_key.to_hash
+vapid_keypair = WebPush.generate_key.to_hash
 app = Rpush::Webpush::App.new
 app.name = 'webpush'
 app.certificate = vapid_keypair.merge(subject: 'mailto:user@example.org').to_json


### PR DESCRIPTION
since `rpush` use `web-push` instead of `webpush`, the command to generate VAPID key is 
```rb
WebPush.generate_key.to_hash # with 'P' uppercase
```