### PR TITLE
Fix invalid retry-after header

### DIFF
--- a/lib/rpush/daemon/webpush/delivery.rb
+++ b/lib/rpush/daemon/webpush/delivery.rb
@@ -92,6 +92,9 @@ module Rpush
 
         def deliver_after_header(response)
           Rpush::Daemon::RetryHeaderParser.parse(response.header['retry-after'])
+        rescue ArgumentError
+          log_error("Invalid retry-after header: #{response.header['retry-after']}")
+          nil
         end
 
         def retry_message

--- a/spec/unit/daemon/webpush/delivery_spec.rb
+++ b/spec/unit/daemon/webpush/delivery_spec.rb
@@ -101,6 +101,25 @@ describe Rpush::Daemon::Webpush::Delivery do
         it_behaves_like 'logs', deliver_after: '2020-10-13 00:00:02'
         it_behaves_like 'process notification'
       end
+
+      context 'when Retry-After header is negative value' do
+        let(:response_header) { { 'retry-after' => '-1' } }
+
+        before do
+          allow(delivery).to receive(:mark_retryable_exponential) do
+            notification.deliver_after = now + 2.seconds
+            notification.retries = 1
+          end
+        end
+
+        it 'retry the notification' do
+          delivery.perform
+          expect(delivery).to have_received(:mark_retryable_exponential).with(notification)
+        end
+
+        it_behaves_like 'logs', deliver_after: '2020-10-13 00:00:02'
+        it_behaves_like 'process notification'
+      end
     end
 
     it_behaves_like 'retry delivery', response_code: 429


### PR DESCRIPTION
We’re seeing some invalid retry-after values, such as `-1` or `-2`, for WebPush, which is causing the following error.

Error type: ArgumentError
Error message: not RFC 2616 compliant date: "-1"
Where: <no information>
Occurred at: Mar 21, 2025 04:26:42 UTC
First seen at: Nov 12, 2024 21:51:53 UTC
Occurrences: 170 (0 since last deploy on <no information>)
Severity: error

URL: <no information>
File: /GEM_ROOT/gems/time-0.3.0/lib/time.rb

Backtrace:
/GEM_ROOT/gems/time-0.3.0/lib/time.rb:599:in httpdate /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/retry_header_parser.rb:18:in parse /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/retry_header_parser.rb:5:in parse /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/webpush/delivery.rb:94:in deliver_after_header /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/webpush/delivery.rb:78:in retry_delivery /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/webpush/delivery.rb:71:in process_response /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/webpush/delivery.rb:35:in perform /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/dispatcher/http.rb:12:in dispatch /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/dispatcher_loop.rb:66:in dispatch /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/dispatcher_loop.rb:35:in block (2 levels) in start /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/dispatcher_loop.rb:25:in loop /GEM_ROOT/bundler/gems/rpush-4ab018597541/lib/rpush/daemon/dispatcher_loop.rb:25:in block in start