### PR TITLE
ostruct won't be part of ruby anymore starting from 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support for proxying HTTP requests [\#728](https://github.com/rpush/rpush/pull/728) ([jaspreet-3911](https://github.com/jaspreet-3911))
 * Fix active record logger dependency for older rails versions that was breaking the build [\#731](https://github.com/rpush/rpush/pull/731) ([SixiS](https://github.com/sixis))
+* Adds ostruct to gemspec (which wont be bundled with ruby 3.5 anymore see [here](https://github.com/ruby/ruby/blob/4eaa245fccd3dd9a61fe1b5f114a6fb47907640a/lib/bundled_gems.rb#L18))
 
 [Full Changelog](https://github.com/rpush/rpush/compare/v9.2.0...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Support for proxying HTTP requests [\#728](https://github.com/rpush/rpush/pull/728) ([jaspreet-3911](https://github.com/jaspreet-3911))
 * Fix active record logger dependency for older rails versions that was breaking the build [\#731](https://github.com/rpush/rpush/pull/731) ([SixiS](https://github.com/sixis))
-* Adds ostruct to gemspec (which wont be bundled with ruby 3.5 anymore see [here](https://github.com/ruby/ruby/blob/4eaa245fccd3dd9a61fe1b5f114a6fb47907640a/lib/bundled_gems.rb#L18))
+* Specify ostruct dependency ([not bundled with ruby since 3.5](https://github.com/ruby/ruby/blob/4eaa245fccd3dd9a61fe1b5f114a6fb47907640a/lib/bundled_gems.rb#L18)) [\#740](https://github.com/rpush/rpush/pull/740) ([grekko-headacy](https://github.com/grekko-headacy))
 
 [Full Changelog](https://github.com/rpush/rpush/compare/v9.2.0...HEAD)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       multi_json (~> 1.0)
       net-http-persistent
       net-http2 (~> 0.18, >= 0.18.3)
+      ostruct
       railties
       rainbow
       thor (>= 0.18.1, < 2.0)
@@ -121,6 +122,7 @@ GEM
       racc (~> 1.4)
     openssl (3.2.0)
     os (1.1.4)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rainbow'
   s.add_runtime_dependency 'web-push'
   s.add_runtime_dependency 'googleauth'
+  s.add_runtime_dependency 'ostruct'
 
   s.add_development_dependency 'debug'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
addresses #739 