### PR TITLE
Add link to web-push gem to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ In order to send the same message to multiple devices, create one
 `Notification` per device, as passing multiple subscriptions at once as
 `registration_ids` is not supported.
 
+For more information on Web Push, see the [pushpad/web-push](https://github.com/pushpad/web-push) documentation.
 
 ### Running Rpush
 


### PR DESCRIPTION
Add a link to the documentation of the `web-push` gem, which is the gem used by this library for Web Push Notifications.

See https://github.com/rpush/rpush/issues/741 for more details